### PR TITLE
perf: defer Google Analytics with requestIdleCallback

### DIFF
--- a/src/meta/ga4.astro
+++ b/src/meta/ga4.astro
@@ -3,21 +3,22 @@
     function gtag() {
         dataLayer.push(arguments);
     }
-    gtag('js', new Date());
 
     const loadGA = () => {
+        gtag('js', new Date());
         const script = document.createElement('script');
         script.async = true;
         script.src = 'https://www.googletagmanager.com/gtag/js?id=G-ZGT4BC0C4P';
         script.onload = () => {
             gtag('config', 'G-ZGT4BC0C4P');
         };
+        script.onerror = () => console.warn('GA4 failed to load');
         document.head.appendChild(script);
     };
 
     if ('requestIdleCallback' in window) {
-        requestIdleCallback(loadGA);
+        requestIdleCallback(loadGA, { timeout: 3000 });
     } else {
-        setTimeout(loadGA, 2000);
+        setTimeout(loadGA, 1000);
     }
 </script>

--- a/src/meta/ga4.astro
+++ b/src/meta/ga4.astro
@@ -1,9 +1,3 @@
-<!-- Google tag (gtag.js) -->
-<script
-    is:inline
-    async
-    src="https://www.googletagmanager.com/gtag/js?id=G-ZGT4BC0C4P"></script>
-
 <script is:raw is:inline>
     window.dataLayer = window.dataLayer || [];
     function gtag() {
@@ -11,5 +5,19 @@
     }
     gtag('js', new Date());
 
-    gtag('config', 'G-ZGT4BC0C4P');
+    const loadGA = () => {
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = 'https://www.googletagmanager.com/gtag/js?id=G-ZGT4BC0C4P';
+        script.onload = () => {
+            gtag('config', 'G-ZGT4BC0C4P');
+        };
+        document.head.appendChild(script);
+    };
+
+    if ('requestIdleCallback' in window) {
+        requestIdleCallback(loadGA);
+    } else {
+        setTimeout(loadGA, 2000);
+    }
 </script>


### PR DESCRIPTION
Defer gtag.js download until the browser is idle instead of loading it synchronously on page load. Falls back to setTimeout for browsers without requestIdleCallback support.

Closes LYO-22