### PR TITLE
perf: delay GTM loading and add dns-prefetch for fonts

### DIFF
--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -88,6 +88,8 @@ const author = article?.author ?? SITE_AUTHOR;
 
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
+        <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
         <link
             href="https://fonts.googleapis.com/css2?family=Saira:wght@400..700&display=swap"
             rel="stylesheet"

--- a/src/meta/ga4.astro
+++ b/src/meta/ga4.astro
@@ -17,8 +17,8 @@
     };
 
     if ('requestIdleCallback' in window) {
-        requestIdleCallback(loadGA, { timeout: 3000 });
+        requestIdleCallback(loadGA, { timeout: 5000 });
     } else {
-        setTimeout(loadGA, 1000);
+        setTimeout(loadGA, 3000);
     }
 </script>


### PR DESCRIPTION
Reduces main-thread contention during initial page load on mobile.

- Increase GTM requestIdleCallback timeout from 3s to 5s
- Increase GTM fallback setTimeout from 1s to 3s
- Add dns-prefetch hints for Google Fonts origins