### PR TITLE
feat: add entry animations and view transitions

### DIFF
--- a/src/components/sections/hero.astro
+++ b/src/components/sections/hero.astro
@@ -17,19 +17,22 @@ const currentDate = new Date().toDateString();
             </a>
         </div>
         <div
-            class="line-before line-after relative flex w-full flex-col items-center justify-center gap-6 p-4 text-center sm:items-start sm:text-start"
+            class="line-before line-after line-animate relative flex w-full flex-col items-center justify-center gap-6 p-4 text-center sm:items-start sm:text-start"
+            style="--delay: 150ms"
         >
             <h1
-                class="font-sans text-[120px] leading-normal font-bold lg:text-[160px] xl:text-[200px]"
+                class="animate-fade-slide-up font-sans text-[120px] leading-normal font-bold lg:text-[160px] xl:text-[200px]"
+                style="--delay: 0ms"
             >
                 Hi.
             </h1>
             <p
-                class="text-2xl leading-normal md:text-4xl lg:text-5xl xl:text-6xl"
+                class="animate-fade-slide-up text-2xl leading-normal md:text-4xl lg:text-5xl xl:text-6xl"
+                style="--delay: 100ms"
             >
                 I'm Liang, passionate Web Engineer.
             </p>
-            <ul class="flex flex-wrap justify-center gap-4 sm:justify-start">
+            <ul class="animate-fade-in flex flex-wrap justify-center gap-4 sm:justify-start" style="--delay: 250ms">
                 <li>
                     <a href="/posts" class="link">
                         <span class="relative">My writings</span>
@@ -43,7 +46,7 @@ const currentDate = new Date().toDateString();
                 </li>
             </ul>
         </div>
-        <p class="justify-self-end p-4 text-black/20">
+        <p class="animate-fade-in justify-self-end p-4 text-black/20" style="--delay: 400ms">
             {currentDate}
         </p>
     </div>

--- a/src/layouts/blogPost.astro
+++ b/src/layouts/blogPost.astro
@@ -35,11 +35,12 @@ const updatedDate = frontmatter.updatedAt?.toLocaleDateString('en-US', {
         <div
             class="container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200"
         >
-            <p class="p-4 text-black/20">Another wonderful day</p>
+            <p class="animate-fade-slide-up p-4 text-black/20" style="--delay: 0ms">Another wonderful day</p>
             <div
-                class="line-before line-after relative flex-1 p-4 md:p-16 xl:py-32"
+                class="line-before line-after line-animate relative flex-1 p-4 md:p-16 xl:py-32"
+                style="--delay: 150ms"
             >
-                <article class="prose prose-stone max-w-[720px]">
+                <article class="animate-fade-in prose prose-stone max-w-[720px]" style="--delay: 250ms">
                     <h1>{frontmatter.title}</h1>
                     <div class="mb-6 text-stone-500">
                         <p>{publishDate}</p>
@@ -74,7 +75,8 @@ const updatedDate = frontmatter.updatedAt?.toLocaleDateString('en-US', {
             </div>
             <a
                 href="/posts"
-                class="self-end p-4 text-black/20 hover:text-black/50"
+                class="animate-fade-in self-end p-4 text-black/20 hover:text-black/50"
+                style="--delay: 500ms"
             >
                 &larr; Back to Posts
             </a>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import GA4 from '../meta/ga4.astro';
+import { ClientRouter } from 'astro:transitions';
 import {
     SITE_NAME,
     SITE_DESCRIPTION,
@@ -85,6 +86,8 @@ const author = article?.author ?? SITE_AUTHOR;
         <meta name="twitter:image" content={imageUrl} />
         <meta name="twitter:site" content={TWITTER_HANDLE} />
         <meta name="twitter:creator" content={TWITTER_HANDLE} />
+
+        <ClientRouter />
 
         <GA4 />
     </head>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -18,12 +18,12 @@ const tags = await getAllPublishedTags();
         <div
             class="container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200"
         >
-            <p class="p-4 text-black/20">Another wonderful day</p>
-            <div class="line-before line-after relative flex-1 p-4 md:p-16">
-                <h1 class="mb-8 text-4xl font-bold">Posts</h1>
+            <p class="animate-fade-slide-up p-4 text-black/20" style="--delay: 0ms">Another wonderful day</p>
+            <div class="line-before line-after line-animate relative flex-1 p-4 md:p-16" style="--delay: 150ms">
+                <h1 class="animate-fade-slide-up mb-8 text-4xl font-bold" style="--delay: 100ms">Posts</h1>
                 {
                     tags.length > 0 && (
-                        <div class="mb-8 flex max-w-[720px] flex-wrap gap-2">
+                        <div class="animate-fade-in mb-8 flex max-w-[720px] flex-wrap gap-2" style="--delay: 200ms">
                             {tags.map((tag) => (
                                 <TagLink tag={tag} />
                             ))}
@@ -32,7 +32,7 @@ const tags = await getAllPublishedTags();
                 }
                 {
                     posts.length > 0 ? (
-                        <div class="grid max-w-[720px] gap-8">
+                        <div class="animate-fade-in grid max-w-[720px] gap-8" style="--delay: 300ms">
                             {posts.map((post, index) => {
                                 const borderClass = `${
                                     index !== posts.length - 1
@@ -53,7 +53,7 @@ const tags = await getAllPublishedTags();
                     )
                 }
             </div>
-            <a href="/" class="self-end p-4 text-black/20 hover:text-black/50">
+            <a href="/" class="animate-fade-in self-end p-4 text-black/20 hover:text-black/50" style="--delay: 500ms">
                 &larr; Back to Home
             </a>
         </div>

--- a/src/pages/posts/tags/[tag].astro
+++ b/src/pages/posts/tags/[tag].astro
@@ -26,15 +26,15 @@ const posts = await getPublishedPostsByTag(tag);
         <div
             class="container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200"
         >
-            <p class="p-4 text-black/20">Browsing by tag</p>
-            <div class="line-before line-after relative flex-1 p-4 md:p-16">
-                <h1 class="mb-3 text-4xl font-bold">#{tag}</h1>
-                <p class="mb-8 text-stone-600">
+            <p class="animate-fade-slide-up p-4 text-black/20" style="--delay: 0ms">Browsing by tag</p>
+            <div class="line-before line-after line-animate relative flex-1 p-4 md:p-16" style="--delay: 150ms">
+                <h1 class="animate-fade-slide-up mb-3 text-4xl font-bold" style="--delay: 100ms">#{tag}</h1>
+                <p class="animate-fade-in mb-8 text-stone-600" style="--delay: 200ms">
                     {posts.length} post{posts.length === 1 ? '' : 's'}
                 </p>
                 {
                     posts.length > 0 ? (
-                        <div class="grid max-w-[720px] gap-8">
+                        <div class="animate-fade-in grid max-w-[720px] gap-8" style="--delay: 300ms">
                             {posts.map((post, index) => {
                                 const borderClass = `${
                                     index !== posts.length - 1
@@ -57,7 +57,8 @@ const posts = await getPublishedPostsByTag(tag);
             </div>
             <a
                 href="/posts"
-                class="self-end p-4 text-black/20 hover:text-black/50"
+                class="animate-fade-in self-end p-4 text-black/20 hover:text-black/50"
+                style="--delay: 500ms"
             >
                 &larr; Back to Posts
             </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,3 +46,60 @@ body {
 .link {
   @apply relative inline-block p-2 before:absolute before:inset-0 before:origin-bottom before:scale-y-10 before:transform before:bg-emerald-300 before:transition-transform before:duration-300 before:ease-in-out hover:before:scale-y-100;
 }
+
+@keyframes fadeSlideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes lineDrawIn {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.animate-fade-slide-up {
+  animation: fadeSlideUp 400ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--delay, 0ms);
+}
+
+.animate-fade-in {
+  animation: fadeIn 400ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--delay, 0ms);
+}
+
+.line-animate::before,
+.line-animate::after {
+  animation: lineDrawIn 500ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--delay, 0ms);
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-slide-up,
+  .animate-fade-in,
+  .line-animate::before,
+  .line-animate::after {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## LYO-25: Add entry animations to improve perceived performance and visual polish

### Changes

- **Hero section**: Staggered fade-in + slide-up animations for heading, subtitle, links, and date
- **Decorative lines**: Draw-in animation on horizontal rules
- **Blog pages**: Entry animations for post lists and content
- **View Transitions API**: Smooth page-to-page transitions (Chrome 111+, Safari 17.4+)

### Technical Details

- Pure CSS animations using `transform` and `opacity` only (GPU-accelerated)
- Respects `prefers-reduced-motion` — animations disabled for users who prefer reduced motion
- Short durations (300-500ms) with smooth deceleration easing
- No layout shift — elements occupy full space before animation starts
- No JS animation libraries

### Files Modified

- `src/styles/global.css` — animation keyframes and utility classes
- `src/components/sections/hero.astro` — hero entry animations
- `src/layouts/layout.astro` — View Transitions meta tag
- `src/layouts/blogPost.astro` — article fade-in
- `src/pages/posts/index.astro` — post list animations
- `src/pages/posts/tags/[tag].astro` — tag page animations