### PR TITLE
fix(ci): add Chrome flags to resolve Lighthouse NO_FCP error

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,7 +3,8 @@
     "collect": {
       "numberOfRuns": 3,
       "settings": {
-        "preset": "desktop"
+        "preset": "desktop",
+        "chromeFlags": "--no-sandbox --disable-gpu --disable-dev-shm-usage"
       }
     },
     "assert": {


### PR DESCRIPTION
Headless Chrome in GitHub Actions was failing to paint content (NO_FCP error).

Added `--no-sandbox --disable-gpu --disable-dev-shm-usage` flags to improve CI rendering reliability.

Fixes the failing Lighthouse Audit workflow (run 26118534920).