### PR TITLE
fix(layout): show animated content before JS runs

### DIFF
--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -39,12 +39,16 @@ const author = article?.author ?? SITE_AUTHOR;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" class="no-js">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="generator" content={Astro.generator} />
+
+        <script is:inline>
+            document.documentElement.classList.replace('no-js', 'js-enabled');
+        </script>
 
         <ClientRouter />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,7 +70,7 @@ body {
   }
 }
 
-[data-animate] {
+.js-enabled [data-animate] {
   opacity: 0;
 }
 
@@ -85,7 +85,7 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-animate] {
+  .js-enabled [data-animate] {
     opacity: 1;
   }
 


### PR DESCRIPTION
Elements with `[data-animate]` were hidden by default (`opacity: 0`), causing NO_FCP errors when JS was delayed. Now content is visible by default and only hidden when JS is confirmed running via the `js-enabled` class.