### PR TITLE
fix(layout): show content before JS to fix Lighthouse NO_FCP

### DIFF
--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -39,16 +39,12 @@ const author = article?.author ?? SITE_AUTHOR;
 ---
 
 <!doctype html>
-<html lang="en" class="no-js">
+<html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="generator" content={Astro.generator} />
-
-        <script is:inline>
-            document.documentElement.classList.replace('no-js', 'js-enabled');
-        </script>
 
         <ClientRouter />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,25 +70,17 @@ body {
   }
 }
 
-.js-enabled [data-animate] {
-  opacity: 0;
-}
-
 .animate-fade-in {
-  animation: fadeIn 0.4s ease-out both;
+  animation: fadeIn 0.4s ease-out backwards;
   will-change: opacity;
 }
 
 .animate-slide-up {
-  animation: slideUp 0.4s ease-out both;
+  animation: slideUp 0.4s ease-out backwards;
   will-change: opacity, transform;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .js-enabled [data-animate] {
-    opacity: 1;
-  }
-
   .animate-fade-in,
   .animate-slide-up {
     animation: none;


### PR DESCRIPTION
Removed `opacity: 0` from `[data-animate]` so content is visible on initial load. Animation keyframes handle the initial hidden state via `animation-fill-mode: backwards`. FCP is now recorded before JS adds animation classes.