### PR TITLE
fix(styles): disable entry animations on mobile to fix FCP

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,14 +70,16 @@ body {
   }
 }
 
-.animate-fade-in {
-  animation: fadeIn 0.4s ease-out backwards;
-  will-change: opacity;
-}
+@media (min-width: 640px) {
+  .animate-fade-in {
+    animation: fadeIn 0.4s ease-out backwards;
+    will-change: opacity;
+  }
 
-.animate-slide-up {
-  animation: slideUp 0.4s ease-out backwards;
-  will-change: opacity, transform;
+  .animate-slide-up {
+    animation: slideUp 0.4s ease-out backwards;
+    will-change: opacity, transform;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -86,7 +86,5 @@ body {
   .animate-fade-in,
   .animate-slide-up {
     animation: none;
-    opacity: 1;
-    transform: none;
   }
 }


### PR DESCRIPTION
Entry animations with `opacity: 0` cause NO_FCP on throttled mobile Lighthouse runs. Now animations only run on screens >= 640px (sm breakpoint). Mobile users see content immediately with no animation.\n\n### Changes\n- Wrapped `.animate-fade-in` and `.animate-slide-up` in `@media (min-width: 640px)`\n- Removed dead `opacity: 1` and `transform: none` from `prefers-reduced-motion` block