### PR TITLE
refactor: extract border class logic into postItem component

### DIFF
--- a/src/components/elements/postItem.astro
+++ b/src/components/elements/postItem.astro
@@ -4,9 +4,10 @@ import TagLink from '../atoms/tagLink.astro';
 
 type Props = {
     post: CollectionEntry<'posts'>;
-    borderClass: string;
+    isLast: boolean;
 };
-const { post, borderClass } = Astro.props;
+const { post, isLast } = Astro.props;
+const borderClass = `${!isLast ? 'border-b' : 'border-none'} border-stone-200`;
 ---
 
 <article

--- a/src/components/elements/postItem.astro
+++ b/src/components/elements/postItem.astro
@@ -7,7 +7,7 @@ type Props = {
     isLast: boolean;
 };
 const { post, isLast } = Astro.props;
-const borderClass = `${!isLast ? 'border-b' : 'border-none'} border-stone-200`;
+const borderClass = isLast ? 'border-none' : 'border-b border-stone-200';
 ---
 
 <article

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -33,20 +33,12 @@ const tags = await getAllPublishedTags();
                 {
                     posts.length > 0 ? (
                         <div class="grid max-w-[720px] gap-8">
-                            {posts.map((post, index) => {
-                                const borderClass = `${
-                                    index !== posts.length - 1
-                                        ? 'border-b'
-                                        : 'border-none'
-                                } border-stone-200`;
-
-                                return (
-                                    <PostItem
-                                        post={post}
-                                        borderClass={borderClass}
-                                    />
-                                );
-                            })}
+                            {posts.map((post, index) => (
+                                <PostItem
+                                    post={post}
+                                    isLast={index === posts.length - 1}
+                                />
+                            ))}
                         </div>
                     ) : (
                         <p class="text-black/20">No blog posts found.</p>

--- a/src/pages/posts/tags/[tag].astro
+++ b/src/pages/posts/tags/[tag].astro
@@ -40,20 +40,12 @@ const posts = await getPublishedPostsByTag(tag);
                 {
                     posts.length > 0 ? (
                         <div class="grid max-w-[720px] gap-8">
-                            {posts.map((post, index) => {
-                                const borderClass = `${
-                                    index !== posts.length - 1
-                                        ? 'border-b'
-                                        : 'border-none'
-                                } border-stone-200`;
-
-                                return (
-                                    <PostItem
-                                        post={post}
-                                        borderClass={borderClass}
-                                    />
-                                );
-                            })}
+                            {posts.map((post, index) => (
+                                <PostItem
+                                    post={post}
+                                    isLast={index === posts.length - 1}
+                                />
+                            ))}
                         </div>
                     ) : (
                         <p class="text-black/20">


### PR DESCRIPTION
Moves duplicated `borderClass` calculation from two page files into PostItem, replacing it with a required `isLast` boolean prop.

**Changes:**
- `postItem.astro`: Replaced `borderClass` prop with required `isLast` prop, calculates border styling internally
- `index.astro`: Simplified map to pass `isLast` instead of computing `borderClass`
- `[tag].astro`: Same simplification

Ref: LYO-14