### PR TITLE
perf(layout): preload Saira font and use optional display to eliminate layout shift

### DIFF
--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -43,6 +43,13 @@ const author = article?.author ?? SITE_AUTHOR;
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <link
+            rel="preload"
+            href="/fonts/saira-variable-latin.woff2"
+            as="font"
+            type="font/woff2"
+            crossorigin
+        />
         <meta name="generator" content={Astro.generator} />
         <title>{pageTitle}</title>
         <meta name="description" content={description} />


### PR DESCRIPTION
## Problem

The live site experiences a layout shift (CLS) on initial load due to font swapping.

## Changes

- **Preload font**: Added `<link rel="preload">` for Saira variable font in `<head>` to fetch earlier
- **font-display: optional**: Changed from `swap` to `optional` to prevent the fallback→custom font swap that causes layout shift

## How it works

`font-display: optional` only uses the custom font if it loads before the first paint. If not, it stays with the system fallback, avoiding any layout shift.

Ref: LYO-26
