### PR TITLE
chore: add check and format scripts to package.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,12 @@ npx astro check      # Type-check the project
 
 ## Key Commands
 
-| Command | Description |
-|---------|-------------|
-| `npm run dev` | Start Astro dev server |
-| `npm run build` | Build static site for production |
+| Command           | Description                      |
+| ----------------- | -------------------------------- |
+| `npm run dev`     | Start Astro dev server           |
+| `npm run build`   | Build static site for production |
 | `npm run preview` | Preview production build locally |
-| `npm run astro` | Run Astro CLI commands directly |
+| `npm run astro`   | Run Astro CLI commands directly  |
 | `npx astro check` | Type-check with `@astrojs/check` |
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,8 @@ npm install          # Install dependencies
 npm run dev          # Start dev server
 npm run build        # Build for production
 npm run preview      # Preview production build
-npx astro check      # Type-check the project
+npm run check        # Type-check the project
+npm run format       # Format code with Prettier
 ```
 
 ## Key Commands
@@ -61,7 +62,8 @@ npx astro check      # Type-check the project
 | `npm run build`   | Build static site for production |
 | `npm run preview` | Preview production build locally |
 | `npm run astro`   | Run Astro CLI commands directly  |
-| `npx astro check` | Type-check with `@astrojs/check` |
+| `npm run check`   | Type-check with `@astrojs/check` |
+| `npm run format`  | Format code with Prettier        |
 
 ---
 
@@ -159,8 +161,8 @@ npx astro check      # Type-check the project
 ## Before Committing
 
 - Run `npm run build` to verify the build passes
-- Run `npx astro check` for type-checking
-- Run Prettier formatting (auto-applied if configured)
+- Run `npm run check` for type-checking
+- Run `npm run format` for formatting
 - Review `git diff` before staging
 - **Never force push** — use `git commit --fixup` or a separate commit instead of amending
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "check": "astro check",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.18",

--- a/src/components/elements/postItem.astro
+++ b/src/components/elements/postItem.astro
@@ -10,9 +10,7 @@ const { post, isLast } = Astro.props;
 const borderClass = isLast ? 'border-none' : 'border-b border-stone-200';
 ---
 
-<article
-    class={`pb-8 ${borderClass}`}
->
+<article class={`pb-8 ${borderClass}`}>
     <h2 class="mb-2 text-2xl font-semibold">
         <a href={`/posts/${post.id}`} class="hover:text-black/60">
             {post.data.title}

--- a/src/content/posts/content-migration-between-sanity-projects.md
+++ b/src/content/posts/content-migration-between-sanity-projects.md
@@ -219,19 +219,15 @@ This is the most straightforward way to perform a bulk migration. The process in
 2.  **Export the Specific Document Type**
     Use the `sanity dataset export` command with the `--types` flag to specify which document type you want. This command will create a compressed `.tar.gz` file.
 
-        ```bash
-        # Replace 'yourDocType' with the actual name of your schema type (e.g., 'post', 'product')
-
-    \*\*\* Add File: /Users/liangsun/Developer/lyonsun/lyonsun.github.io/src/content/posts/editorconfig-vs-prettier.md
-
+    ```bash
+    # Replace 'yourDocType' with the actual name of your schema type (e.g., 'post', 'product')
+*** Add File: /Users/liangsun/Developer/lyonsun/lyonsun.github.io/src/content/posts/editorconfig-vs-prettier.md
 ---
-
 title: EditorConfig vs Prettier
 description: Do we need both .editorconfig and .prettierrc in a project, or just one of them would be enough?
 pubDate: 2025-07-30
 author: Google Gemini 2.5 Pro
 aiGeneratedContent: true
-
 ---
 
 ### Decoding Your Dev Environment: .editorconfig vs. .prettierrc

--- a/src/content/posts/content-migration-between-sanity-projects.md
+++ b/src/content/posts/content-migration-between-sanity-projects.md
@@ -219,15 +219,19 @@ This is the most straightforward way to perform a bulk migration. The process in
 2.  **Export the Specific Document Type**
     Use the `sanity dataset export` command with the `--types` flag to specify which document type you want. This command will create a compressed `.tar.gz` file.
 
-    ```bash
-    # Replace 'yourDocType' with the actual name of your schema type (e.g., 'post', 'product')
-*** Add File: /Users/liangsun/Developer/lyonsun/lyonsun.github.io/src/content/posts/editorconfig-vs-prettier.md
+        ```bash
+        # Replace 'yourDocType' with the actual name of your schema type (e.g., 'post', 'product')
+
+    \*\*\* Add File: /Users/liangsun/Developer/lyonsun/lyonsun.github.io/src/content/posts/editorconfig-vs-prettier.md
+
 ---
+
 title: EditorConfig vs Prettier
 description: Do we need both .editorconfig and .prettierrc in a project, or just one of them would be enough?
 pubDate: 2025-07-30
 author: Google Gemini 2.5 Pro
 aiGeneratedContent: true
+
 ---
 
 ### Decoding Your Dev Environment: .editorconfig vs. .prettierrc


### PR DESCRIPTION
Add `check` and `format` scripts to package.json since `@astrojs/check`, `typescript`, and `prettier` are already installed as devDependencies.\n\n- `npm run check` - runs `astro check` for type checking\n- `npm run format` - runs `prettier --write .` for formatting\n\nRef: LYO-15