### PR TITLE
refactor: extract date formatting utility

### DIFF
--- a/src/components/elements/postItem.astro
+++ b/src/components/elements/postItem.astro
@@ -1,5 +1,6 @@
 ---
 import { type CollectionEntry } from 'astro:content';
+import { formatDate } from '../../lib/posts';
 import TagLink from '../atoms/tagLink.astro';
 
 type Props = {
@@ -17,13 +18,7 @@ const borderClass = isLast ? 'border-none' : 'border-b border-stone-200';
         </a>
     </h2>
     <p class="mb-4 text-black/40">
-        {
-            post.data.pubDate.toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-            })
-        }
+        {formatDate(post.data.pubDate)}
     </p>
     <p class="text-black/60">
         {post.data.description}

--- a/src/layouts/blogPost.astro
+++ b/src/layouts/blogPost.astro
@@ -1,5 +1,6 @@
 ---
 import { type CollectionEntry } from 'astro:content';
+import { formatDate } from '../lib/posts';
 import TagLink from '../components/atoms/tagLink.astro';
 import Layout from './layout.astro';
 
@@ -9,16 +10,10 @@ type Props = {
 
 const { frontmatter } = Astro.props;
 
-const publishDate = frontmatter.pubDate.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-});
-const updatedDate = frontmatter.updatedAt?.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-});
+const publishDate = formatDate(frontmatter.pubDate);
+const updatedDate = frontmatter.updatedAt
+    ? formatDate(frontmatter.updatedAt)
+    : undefined;
 ---
 
 <Layout

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -30,4 +30,17 @@ async function getAllPublishedTags() {
     return Array.from(tags).sort((a, b) => a.localeCompare(b));
 }
 
-export { getPublishedPosts, getPublishedPostsByTag, getAllPublishedTags };
+function formatDate(date: Date): string {
+    return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+    });
+}
+
+export {
+    getPublishedPosts,
+    getPublishedPostsByTag,
+    getAllPublishedTags,
+    formatDate,
+};


### PR DESCRIPTION
Extract repeated `toLocaleDateString` calls into `formatDate` helper in `src/lib/posts.ts`.

- Added `formatDate(date: Date): string` utility
- Updated `blogPost.astro` and `postItem.astro` to use it

Ref: LYO-16