### PR TITLE
chore: remove unused Tailwind v3 config file

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-export default {
-    content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
-    theme: {
-        extend: {},
-    },
-    plugins: [],
-};


### PR DESCRIPTION
Removes `tailwind.config.mjs` which is a legacy Tailwind v3 config file that is no longer detected automatically in v4.

The project uses Tailwind v4 with CSS-based configuration (`@import "tailwindcss"`, `@plugin`, `@theme`) in `src/styles/global.css`.

Ref: https://tailwindcss.com/docs/upgrade-guide#using-a-javascript-config-file

Ref: LYO-20