### PR TITLE
refactor: extract reusable PageSection component

### DIFF
--- a/src/components/sections/hero.astro
+++ b/src/components/sections/hero.astro
@@ -1,50 +1,39 @@
 ---
 import ExternalLink from '../atoms/externalLink.astro';
+import PageSection from './pageSection.astro';
 
 const currentDate = new Date().toDateString();
 ---
 
-<section class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20">
-    <div
-        class="container mx-auto grid min-h-screen sm:border-r sm:border-l sm:border-stone-200"
-    >
-        <div class="self-end p-4">
-            <a
-                href="/posts/10247-lines-of-code"
-                class="text-black/20 hover:text-black/50"
-            >
-                10247 lines of code
-            </a>
-        </div>
-        <div
-            class="line-before line-after relative flex w-full flex-col items-center justify-center gap-6 p-4 text-center sm:items-start sm:text-start"
-        >
-            <h1
-                class="font-sans text-[120px] leading-normal font-bold lg:text-[160px] xl:text-[200px]"
-            >
-                Hi.
-            </h1>
-            <p
-                class="text-2xl leading-normal md:text-4xl lg:text-5xl xl:text-6xl"
-            >
-                I'm Liang, passionate Web Engineer.
-            </p>
-            <ul class="flex flex-wrap justify-center gap-4 sm:justify-start">
-                <li>
-                    <a href="/posts" class="link">
-                        <span class="relative">My writings</span>
-                    </a>
-                </li>
-                <li>
-                    <ExternalLink
-                        url="https://www.linkedin.com/in/lyonsun7"
-                        title="LinkedIn profile"
-                    />
-                </li>
-            </ul>
-        </div>
-        <p class="justify-self-end p-4 text-black/20">
-            {currentDate}
-        </p>
+<PageSection
+    layout="grid"
+    contentClass="flex w-full flex-col items-center justify-center gap-6 text-center sm:items-start sm:text-start"
+>
+    <div slot="top" class="self-end p-4">
+        <a href="/posts/10247-lines-of-code" class="text-black/20 hover:text-black/50">
+            10247 lines of code
+        </a>
     </div>
-</section>
+    <h1 class="font-sans text-[120px] leading-normal font-bold lg:text-[160px] xl:text-[200px]">
+        Hi.
+    </h1>
+    <p class="text-2xl leading-normal md:text-4xl lg:text-5xl xl:text-6xl">
+        I'm Liang, passionate Web Engineer.
+    </p>
+    <ul class="flex flex-wrap justify-center gap-4 sm:justify-start">
+        <li>
+            <a href="/posts" class="link">
+                <span class="relative">My writings</span>
+            </a>
+        </li>
+        <li>
+            <ExternalLink
+                url="https://www.linkedin.com/in/lyonsun7"
+                title="LinkedIn profile"
+            />
+        </li>
+    </ul>
+    <div slot="bottom" class="justify-self-end p-4 text-black/20">
+        {currentDate}
+    </div>
+</PageSection>

--- a/src/components/sections/hero.astro
+++ b/src/components/sections/hero.astro
@@ -10,11 +10,16 @@ const currentDate = new Date().toDateString();
     contentClass="flex w-full flex-col items-center justify-center gap-6 text-center sm:items-start sm:text-start"
 >
     <div slot="top" class="self-end p-4">
-        <a href="/posts/10247-lines-of-code" class="text-black/20 hover:text-black/50">
+        <a
+            href="/posts/10247-lines-of-code"
+            class="text-black/20 hover:text-black/50"
+        >
             10247 lines of code
         </a>
     </div>
-    <h1 class="font-sans text-[120px] leading-normal font-bold lg:text-[160px] xl:text-[200px]">
+    <h1
+        class="font-sans text-[120px] leading-normal font-bold lg:text-[160px] xl:text-[200px]"
+    >
         Hi.
     </h1>
     <p class="text-2xl leading-normal md:text-4xl lg:text-5xl xl:text-6xl">

--- a/src/components/sections/pageSection.astro
+++ b/src/components/sections/pageSection.astro
@@ -15,23 +15,34 @@ const {
     contentClass = 'flex-1',
 } = Astro.props;
 
-const containerClasses = layout === 'grid'
-    ? 'container mx-auto grid min-h-screen sm:border-r sm:border-l sm:border-stone-200'
-    : 'container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200';
+const containerClasses =
+    layout === 'grid'
+        ? 'container mx-auto grid min-h-screen sm:border-r sm:border-l sm:border-stone-200'
+        : 'container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200';
 ---
 
 <section class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20">
     <div class={containerClasses}>
         {topText && <p class="p-4 text-black/20">{topText}</p>}
         <slot name="top" />
-        <div class:list={['line-before line-after relative p-4 md:p-16', contentClass]}>
+        <div
+            class:list={[
+                'line-before line-after relative p-4 md:p-16',
+                contentClass,
+            ]}
+        >
             <slot />
         </div>
-        {bottomHref && (
-            <a href={bottomHref} class="self-end p-4 text-black/20 hover:text-black/50">
-                {bottomText}
-            </a>
-        )}
+        {
+            bottomHref && (
+                <a
+                    href={bottomHref}
+                    class="self-end p-4 text-black/20 hover:text-black/50"
+                >
+                    {bottomText}
+                </a>
+            )
+        }
         <slot name="bottom" />
     </div>
 </section>

--- a/src/components/sections/pageSection.astro
+++ b/src/components/sections/pageSection.astro
@@ -1,0 +1,37 @@
+---
+interface Props {
+    topText?: string;
+    bottomHref?: string;
+    bottomText?: string;
+    layout?: 'flex' | 'grid';
+    contentClass?: string;
+}
+
+const {
+    topText,
+    bottomHref,
+    bottomText = '← Back',
+    layout = 'flex',
+    contentClass = 'flex-1',
+} = Astro.props;
+
+const containerClasses = layout === 'grid'
+    ? 'container mx-auto grid min-h-screen sm:border-r sm:border-l sm:border-stone-200'
+    : 'container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200';
+---
+
+<section class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20">
+    <div class={containerClasses}>
+        {topText && <p class="p-4 text-black/20">{topText}</p>}
+        <slot name="top" />
+        <div class:list={['line-before line-after relative p-4 md:p-16', contentClass]}>
+            <slot />
+        </div>
+        {bottomHref && (
+            <a href={bottomHref} class="self-end p-4 text-black/20 hover:text-black/50">
+                {bottomText}
+            </a>
+        )}
+        <slot name="bottom" />
+    </div>
+</section>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -43,9 +43,7 @@ const imageUrl = image
     : new URL(defaultOgImage.src, Astro.site).toString();
 const imageWidth = image ? undefined : defaultOgImage.attributes.width;
 const imageHeight = image ? undefined : defaultOgImage.attributes.height;
-const imageMimeType = image
-    ? undefined
-    : 'image/webp';
+const imageMimeType = image ? undefined : 'image/webp';
 ---
 
 <!doctype html>
@@ -82,9 +80,24 @@ const imageMimeType = image
         <meta property="og:description" content={description} />
         <meta property="og:url" content={canonicalUrl} />
         <meta property="og:image" content={imageUrl} />
-        {imageWidth && <meta property="og:image:width" content={String(imageWidth)} />}
-        {imageHeight && <meta property="og:image:height" content={String(imageHeight)} />}
-        {imageMimeType && <meta property="og:image:type" content={imageMimeType} />}
+        {
+            imageWidth && (
+                <meta property="og:image:width" content={String(imageWidth)} />
+            )
+        }
+        {
+            imageHeight && (
+                <meta
+                    property="og:image:height"
+                    content={String(imageHeight)}
+                />
+            )
+        }
+        {
+            imageMimeType && (
+                <meta property="og:image:type" content={imageMimeType} />
+            )
+        }
         <meta property="og:site_name" content={SITE_NAME} />
         <meta property="og:locale" content={SITE_LOCALE} />
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,26 +1,16 @@
 ---
 import Layout from '../layouts/layout.astro';
+import PageSection from '../components/sections/pageSection.astro';
 ---
 
 <Layout title="Page not found" noindex={true}>
-    <section
-        class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20"
+    <PageSection
+        bottomHref="/"
+        bottomText="← Back to Home"
+        layout="grid"
+        contentClass="flex w-full flex-col items-center justify-center gap-6 text-center sm:items-start sm:text-start"
     >
-        <div
-            class="container mx-auto grid min-h-screen sm:border-r sm:border-l sm:border-stone-200"
-        >
-            <p class="self-end p-4 text-black/20">Are you lost?</p>
-            <div
-                class="line-before line-after relative flex w-full flex-col items-center justify-center gap-6 p-4 text-center sm:items-start sm:text-start"
-            >
-                <h1 class="text-8xl">404</h1>
-            </div>
-            <a
-                href="/"
-                class="justify-self-end p-4 text-black/20 hover:text-black/50"
-            >
-                &larr; Back to Home
-            </a>
-        </div>
-    </section>
+        <p slot="top" class="self-end p-4 text-black/20">Are you lost?</p>
+        <h1 class="text-8xl">404</h1>
+    </PageSection>
 </Layout>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -13,7 +13,11 @@ const tags = await getAllPublishedTags();
     title="My writings"
     description="Writing on web development, TypeScript, Go, and side projects."
 >
-    <PageSection topText="Another wonderful day" bottomHref="/" bottomText="← Back to Home">
+    <PageSection
+        topText="Another wonderful day"
+        bottomHref="/"
+        bottomText="← Back to Home"
+    >
         <h1 class="mb-8 text-4xl font-bold">Posts</h1>
         {
             tags.length > 0 && (

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/layout.astro';
 import PostItem from '../../components/elements/postItem.astro';
 import TagLink from '../../components/atoms/tagLink.astro';
+import PageSection from '../../components/sections/pageSection.astro';
 import { getAllPublishedTags, getPublishedPosts } from '../../lib/posts';
 
 const posts = await getPublishedPosts();
@@ -12,42 +13,30 @@ const tags = await getAllPublishedTags();
     title="My writings"
     description="Writing on web development, TypeScript, Go, and side projects."
 >
-    <section
-        class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20"
-    >
-        <div
-            class="container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200"
-        >
-            <p class="p-4 text-black/20">Another wonderful day</p>
-            <div class="line-before line-after relative flex-1 p-4 md:p-16">
-                <h1 class="mb-8 text-4xl font-bold">Posts</h1>
-                {
-                    tags.length > 0 && (
-                        <div class="mb-8 flex max-w-[720px] flex-wrap gap-2">
-                            {tags.map((tag) => (
-                                <TagLink tag={tag} />
-                            ))}
-                        </div>
-                    )
-                }
-                {
-                    posts.length > 0 ? (
-                        <div class="grid max-w-[720px] gap-8">
-                            {posts.map((post, index) => (
-                                <PostItem
-                                    post={post}
-                                    isLast={index === posts.length - 1}
-                                />
-                            ))}
-                        </div>
-                    ) : (
-                        <p class="text-black/20">No blog posts found.</p>
-                    )
-                }
-            </div>
-            <a href="/" class="self-end p-4 text-black/20 hover:text-black/50">
-                &larr; Back to Home
-            </a>
-        </div>
-    </section>
+    <PageSection topText="Another wonderful day" bottomHref="/" bottomText="← Back to Home">
+        <h1 class="mb-8 text-4xl font-bold">Posts</h1>
+        {
+            tags.length > 0 && (
+                <div class="mb-8 flex max-w-[720px] flex-wrap gap-2">
+                    {tags.map((tag) => (
+                        <TagLink tag={tag} />
+                    ))}
+                </div>
+            )
+        }
+        {
+            posts.length > 0 ? (
+                <div class="grid max-w-[720px] gap-8">
+                    {posts.map((post, index) => (
+                        <PostItem
+                            post={post}
+                            isLast={index === posts.length - 1}
+                        />
+                    ))}
+                </div>
+            ) : (
+                <p class="text-black/20">No blog posts found.</p>
+            )
+        }
+    </PageSection>
 </Layout>

--- a/src/pages/posts/tags/[tag].astro
+++ b/src/pages/posts/tags/[tag].astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../../../layouts/layout.astro';
 import PostItem from '../../../components/elements/postItem.astro';
+import PageSection from '../../../components/sections/pageSection.astro';
 import {
     getAllPublishedTags,
     getPublishedPostsByTag,
@@ -23,43 +24,24 @@ const posts = await getPublishedPostsByTag(tag);
     title={`Posts tagged ${tag}`}
     description={`Writing tagged with ${tag}.`}
 >
-    <section
-        class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20"
-    >
-        <div
-            class="container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200"
-        >
-            <p class="p-4 text-black/20">Browsing by tag</p>
-            <div class="line-before line-after relative flex-1 p-4 md:p-16">
-                <h1 class="mb-3 text-4xl font-bold">
-                    #{tag}
-                </h1>
-                <p class="mb-8 text-stone-600">
-                    {posts.length} post{posts.length === 1 ? '' : 's'}
-                </p>
-                {
-                    posts.length > 0 ? (
-                        <div class="grid max-w-[720px] gap-8">
-                            {posts.map((post, index) => (
-                                <PostItem
-                                    post={post}
-                                    isLast={index === posts.length - 1}
-                                />
-                            ))}
-                        </div>
-                    ) : (
-                        <p class="text-black/20">
-                            No posts found for this tag.
-                        </p>
-                    )
-                }
-            </div>
-            <a
-                href="/posts"
-                class="self-end p-4 text-black/20 hover:text-black/50"
-            >
-                &larr; Back to Posts
-            </a>
-        </div>
-    </section>
+    <PageSection topText="Browsing by tag" bottomHref="/posts" bottomText="← Back to Posts">
+        <h1 class="mb-3 text-4xl font-bold">#{tag}</h1>
+        <p class="mb-8 text-stone-600">
+            {posts.length} post{posts.length === 1 ? '' : 's'}
+        </p>
+        {
+            posts.length > 0 ? (
+                <div class="grid max-w-[720px] gap-8">
+                    {posts.map((post, index) => (
+                        <PostItem
+                            post={post}
+                            isLast={index === posts.length - 1}
+                        />
+                    ))}
+                </div>
+            ) : (
+                <p class="text-black/20">No posts found for this tag.</p>
+            )
+        }
+    </PageSection>
 </Layout>

--- a/src/pages/posts/tags/[tag].astro
+++ b/src/pages/posts/tags/[tag].astro
@@ -24,7 +24,11 @@ const posts = await getPublishedPostsByTag(tag);
     title={`Posts tagged ${tag}`}
     description={`Writing tagged with ${tag}.`}
 >
-    <PageSection topText="Browsing by tag" bottomHref="/posts" bottomText="← Back to Posts">
+    <PageSection
+        topText="Browsing by tag"
+        bottomHref="/posts"
+        bottomText="← Back to Posts"
+    >
         <h1 class="mb-3 text-4xl font-bold">#{tag}</h1>
         <p class="mb-8 text-stone-600">
             {posts.length} post{posts.length === 1 ? '' : 's'}


### PR DESCRIPTION
## Summary

Extracts the shared page layout wrapper (gradient section, container div, top text, content area, bottom link) into a reusable `PageSection` component to reduce duplication across 4 files.

## Changes

- **New:** `src/components/sections/pageSection.astro` — reusable wrapper with props (`topText`, `bottomHref`, `bottomText`, `layout`, `contentClass`) and named slots (`top`, `bottom`)
- **Refactored:** `posts/index.astro` — uses PageSection with default props
- **Refactored:** `posts/tags/[tag].astro` — uses PageSection with default props
- **Refactored:** `404.astro` — uses PageSection with grid layout + named slot for custom top text positioning
- **Refactored:** `hero.astro` — uses PageSection with named slots for reversed top/bottom order

## Test Plan

- [x] `npm run build` passes (25 pages)
- [x] `npm run check` passes (pre-existing type error in astro.config.mjs unrelated)
- [x] `npm run format` applied

Ref: LYO-21