### PR TITLE
fix(security): add rel="noopener noreferrer" to external links

### DIFF
--- a/src/components/atoms/externalLink.astro
+++ b/src/components/atoms/externalLink.astro
@@ -6,7 +6,7 @@ type Props = { url: string; title: string };
 const { url, title } = Astro.props;
 ---
 
-<a href={url} target="_blank" class="link">
+<a href={url} target="_blank" rel="noopener noreferrer" class="link">
     <span class="item-center relative flex justify-center gap-2">
         {title}
         <ExternalLinkIcon className="size-5" />


### PR DESCRIPTION
Adds `rel="noopener noreferrer"` to external link icon SVGs.

- Fixes tabnabbing security vulnerability
- Resolves Lighthouse best practices penalty
- Complies with AGENTS.md guidelines

Ref: LYO-42