### PR TITLE
fix(a11y): remove conflicting role="img" from decorative icon SVGs

### DIFF
--- a/src/components/icons/email.astro
+++ b/src/components/icons/email.astro
@@ -3,7 +3,6 @@ const { ...props } = Astro.props;
 ---
 
 <svg
-    role="img"
     aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 16"

--- a/src/components/icons/github.astro
+++ b/src/components/icons/github.astro
@@ -3,7 +3,6 @@ const { ...props } = Astro.props;
 ---
 
 <svg
-    role="img"
     aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"

--- a/src/components/icons/linkedin.astro
+++ b/src/components/icons/linkedin.astro
@@ -3,7 +3,6 @@ const { ...props } = Astro.props;
 ---
 
 <svg
-    role="img"
     aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 512 512"


### PR DESCRIPTION
Removes `role="img"` from icon SVGs that already have `aria-hidden="true"`.

- These icons are alongside text labels, making them purely decorative
- `role="img"` + `aria-hidden="true"` are contradictory ARIA attributes
- Only `aria-hidden="true"` is correct for decorative icons

Ref: LYO-46