### PR TITLE
fix: replace process.env.SITE_URL with import.meta.env.SITE_URL

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
-    site: process.env.SITE_URL || 'https://lyonsun.github.io',
+    site: import.meta.env.SITE_URL || 'https://lyonsun.github.io',
 
     vite: {
         plugins: [tailwindcss()],


### PR DESCRIPTION
Replaces `process.env.SITE_URL` with `import.meta.env.SITE_URL` in `astro.config.mjs`.

- Uses Astro/Vite-native env access instead of Node.js `process.env`
- Eliminates the ts(2591) type error without adding `@types/node`
- `npm run check` now passes with **0 errors**

Ref: LYO-38