### PR TITLE
fix(a11y): improve low-contrast text

### DIFF
--- a/src/components/sections/hero.astro
+++ b/src/components/sections/hero.astro
@@ -12,7 +12,7 @@ const currentDate = new Date().toDateString();
     <div slot="top" class="self-end p-4">
         <a
             href="/posts/10247-lines-of-code"
-            class="text-black/20 hover:text-black/50"
+            class="text-black/60 hover:text-black/70"
         >
             10247 lines of code
         </a>
@@ -38,7 +38,7 @@ const currentDate = new Date().toDateString();
             />
         </li>
     </ul>
-    <div slot="bottom" class="justify-self-end p-4 text-black/20">
+    <div slot="bottom" class="justify-self-end p-4 text-black/60">
         {currentDate}
     </div>
 </PageSection>

--- a/src/components/sections/pageSection.astro
+++ b/src/components/sections/pageSection.astro
@@ -23,7 +23,7 @@ const containerClasses =
 
 <section class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20">
     <div class={containerClasses}>
-        {topText && <p class="p-4 text-black/20">{topText}</p>}
+        {topText && <p class="p-4 text-black/60">{topText}</p>}
         <slot name="top" />
         <div
             class:list={[
@@ -37,7 +37,7 @@ const containerClasses =
             bottomHref && (
                 <a
                     href={bottomHref}
-                    class="self-end p-4 text-black/20 hover:text-black/50"
+                    class="self-end p-4 text-black/60 hover:text-black/70"
                 >
                     {bottomText}
                 </a>

--- a/src/layouts/blogPost.astro
+++ b/src/layouts/blogPost.astro
@@ -30,7 +30,7 @@ const updatedDate = frontmatter.updatedAt
         <div
             class="container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200"
         >
-            <p class="p-4 text-black/20">Another wonderful day</p>
+            <p class="p-4 text-black/60">Another wonderful day</p>
             <div
                 class="line-before line-after relative flex-1 p-4 md:p-16 xl:py-32"
             >
@@ -71,7 +71,7 @@ const updatedDate = frontmatter.updatedAt
             </div>
             <a
                 href="/posts"
-                class="self-end p-4 text-black/20 hover:text-black/50"
+                class="self-end p-4 text-black/60 hover:text-black/70"
             >
                 &larr; Back to Posts
             </a>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,7 +10,7 @@ import PageSection from '../components/sections/pageSection.astro';
         layout="grid"
         contentClass="flex w-full flex-col items-center justify-center gap-6 text-center sm:items-start sm:text-start"
     >
-        <p slot="top" class="self-end p-4 text-black/20">Are you lost?</p>
+        <p slot="top" class="self-end p-4 text-black/60">Are you lost?</p>
         <h1 class="text-8xl">404</h1>
     </PageSection>
 </Layout>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -39,7 +39,7 @@ const tags = await getAllPublishedTags();
                     ))}
                 </div>
             ) : (
-                <p class="text-black/20">No blog posts found.</p>
+                <p class="text-black/60">No blog posts found.</p>
             )
         }
     </PageSection>

--- a/src/pages/posts/tags/[tag].astro
+++ b/src/pages/posts/tags/[tag].astro
@@ -44,7 +44,7 @@ const posts = await getPublishedPostsByTag(tag);
                     ))}
                 </div>
             ) : (
-                <p class="text-black/20">No posts found for this tag.</p>
+                <p class="text-black/60">No posts found for this tag.</p>
             )
         }
     </PageSection>


### PR DESCRIPTION
## Summary
- Increase low-contrast gradient text from black/20 to black/60
- Darken hover states from black/50 to black/70
- Include matching empty-state text that used the same low-contrast style

## Verification
- npm run build
- npm run check
- npm run format

Ref: LYO-48