### PR TITLE
feat(ci): add biweekly AI blog post workflow

### DIFF
--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -1,0 +1,88 @@
+name: Blog Writer
+
+on:
+  schedule:
+    - cron: "0 9 * * 1,4"
+  workflow_dispatch:
+    inputs:
+      topic_slug:
+        description: "Specific topic slug to generate (optional)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Compose blog post
+        id: compose
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        run: |
+          if [ -n "${{ inputs.topic_slug }}" ]; then
+            node scripts/write-post.mjs "${{ inputs.topic_slug }}"
+          else
+            node scripts/write-post.mjs
+          fi
+
+      - name: Check formatting
+        run: npx prettier --check .
+
+      - name: Type check
+        run: npm run check
+
+      - name: Build
+        run: npm run build
+
+      - name: Create Pull Request
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          BRANCH="blog/${DATE}"
+
+          if git diff --quiet && git ls-files --others --exclude-standard --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git config user.name "lyonsun"
+          git config user.email "sunly917@gmail.com"
+          git checkout -b "$BRANCH"
+          git add src/content/posts/ scripts/topics.json
+          git commit -m "content(posts): add new post for ${DATE}"
+          git push origin "$BRANCH" --force
+
+          PR_EXISTS=$(gh pr list --head "$BRANCH" --json number --jq 'length')
+          if [ "$PR_EXISTS" -eq 0 ]; then
+            BODY=$(cat <<EOF
+          This PR adds an AI-generated blog post draft.
+
+          Topic slug: ${{ inputs.topic_slug || 'first-unused' }}
+
+          **Note:** The post has \`draft: true\` and \`aiGeneratedContent: true\`. Review and remove \`draft: true\` before publishing.
+          EOF
+          )
+            gh pr create \
+              --title "content(posts): add new post for ${DATE}" \
+              --body "$BODY"
+          else
+            echo "PR already exists for branch $BRANCH."
+          fi

--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -34,9 +34,10 @@ jobs:
         id: compose
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          TOPIC_SLUG: ${{ inputs.topic_slug || '' }}
         run: |
-          if [ -n "${{ inputs.topic_slug }}" ]; then
-            node scripts/write-post.mjs "${{ inputs.topic_slug }}"
+          if [ -n "$TOPIC_SLUG" ]; then
+            node scripts/write-post.mjs "$TOPIC_SLUG"
           else
             node scripts/write-post.mjs
           fi
@@ -72,10 +73,11 @@ jobs:
 
           PR_EXISTS=$(gh pr list --head "$BRANCH" --json number --jq 'length')
           if [ "$PR_EXISTS" -eq 0 ]; then
+            SLUG="${{ steps.compose.outputs.topic-slug }}"
             BODY=$(cat <<EOF
           This PR adds an AI-generated blog post draft.
 
-          Topic slug: ${{ inputs.topic_slug || 'first-unused' }}
+          Topic slug: ${SLUG}
 
           **Note:** The post has \`draft: true\` and \`aiGeneratedContent: true\`. Review and remove \`draft: true\` before publishing.
           EOF

--- a/scripts/topics.json
+++ b/scripts/topics.json
@@ -1,0 +1,72 @@
+[
+  {
+    "slug": "how-ai-coding-assistants-work",
+    "title": "How AI Coding Assistants Actually Work",
+    "angle": "Explain the mechanics behind AI coding assistants: how they tokenize your code, understand context, and generate suggestions. Cover the difference between completion-based and chat-based assistants.",
+    "tags": ["ai", "coding-assistants", "llm"],
+    "usedAt": null
+  },
+  {
+    "slug": "building-agentic-workflows-with-llms",
+    "title": "Building Agentic Workflows with LLMs",
+    "angle": "Explore patterns for building autonomous agents that can plan, execute tools, and iterate. Cover loop architectures, tool calling, and common pitfalls like infinite loops and context overflow.",
+    "tags": ["ai", "agentic", "workflow"],
+    "usedAt": null
+  },
+  {
+    "slug": "ai-powered-code-review",
+    "title": "AI-Powered Code Review: Beyond Linting",
+    "angle": "Discuss how LLMs can review code for logic errors, security issues, and architectural concerns beyond what static analysis catches. Compare inline suggestions vs PR-level review.",
+    "tags": ["ai", "code-review", "ci"],
+    "usedAt": null
+  },
+  {
+    "slug": "using-llms-for-automated-test-generation",
+    "title": "Using LLMs for Automated Test Generation",
+    "angle": "Walk through strategies for using LLMs to generate unit tests, integration tests, and edge cases from code context. Cover prompt patterns, validation, and when human oversight is essential.",
+    "tags": ["ai", "testing", "agentic"],
+    "usedAt": null
+  },
+  {
+    "slug": "multi-agent-systems-for-software-development",
+    "title": "Multi-Agent Systems for Software Development",
+    "angle": "Examine architectures where multiple AI agents collaborate on software tasks: a planner agent breaks down work, a coder implements, a reviewer critiques. Discuss coordination patterns and failure modes.",
+    "tags": ["ai", "agentic", "architecture"],
+    "usedAt": null
+  },
+  {
+    "slug": "prompt-engineering-for-code-generation",
+    "title": "Prompt Engineering for Code Generation",
+    "angle": "Practical techniques for crafting prompts that produce better code: providing context, specifying constraints, using examples, requesting explanations, and iterating on output.",
+    "tags": ["ai", "prompt-engineering", "coding"],
+    "usedAt": null
+  },
+  {
+    "slug": "integrating-ai-into-your-ci-cd-pipeline",
+    "title": "Integrating AI into Your CI/CD Pipeline",
+    "angle": "Show how to add AI-powered steps to CI/CD: auto-generating release notes, summarizing PR changes, flagging risky diffs, and suggesting rollback strategies. Cover cost and latency trade-offs.",
+    "tags": ["ai", "ci-cd", "workflow"],
+    "usedAt": null
+  },
+  {
+    "slug": "tools-for-documentation-generation",
+    "title": "LLMs for Automated Documentation Generation",
+    "angle": "Survey approaches for generating docs from code: JSDoc/TSDoc comments, README generation, API reference docs, and changelogs. Discuss quality control and keeping docs in sync with code.",
+    "tags": ["ai", "documentation", "workflow"],
+    "usedAt": null
+  },
+  {
+    "slug": "design-to-code-with-ai",
+    "title": "From Design to Code: AI-Powered UI Generation",
+    "angle": "Analyze the current state of AI tools that convert designs (Figma, screenshots, sketches) into frontend code. Cover what works today, limitations, and practical workflows for web engineers.",
+    "tags": ["ai", "frontend", "design"],
+    "usedAt": null
+  },
+  {
+    "slug": "evaluating-llm-outputs-in-engineering-workflows",
+    "title": "Evaluating LLM Outputs in Engineering Workflows",
+    "angle": "Discuss strategies for evaluating AI-generated code and content: automated tests, manual review checklists, hallucination detection, and building evaluation datasets for your specific domain.",
+    "tags": ["ai", "llm", "workflow", "testing"],
+    "usedAt": null
+  }
+]

--- a/scripts/write-post.mjs
+++ b/scripts/write-post.mjs
@@ -128,7 +128,9 @@ function slugToFileName(dateStr, slug) {
 }
 
 async function main() {
-    const topicSlug = process.argv[2];
+    const args = process.argv.slice(2);
+    const dryRun = args.includes('--dry-run');
+    const topicSlug = args.find((a) => !a.startsWith('--'));
     const topics = readTopics();
 
     let topicIndex;
@@ -173,6 +175,13 @@ async function main() {
             'AI response missing required fields (title, description, or body).',
         );
         process.exit(1);
+    }
+
+    if (dryRun) {
+        console.log(`[dry-run] Would write: ${filePath}`);
+        console.log(`[dry-run] Title: ${result.title}`);
+        console.log(`[dry-run] Topic: ${topic.slug} would be marked as used`);
+        process.exit(0);
     }
 
     if (!existsSync(POSTS_DIR)) {

--- a/scripts/write-post.mjs
+++ b/scripts/write-post.mjs
@@ -17,8 +17,13 @@ const POSTS_DIR = join(__dirname, '..', 'src', 'content', 'posts');
 const REPO_ROOT = join(__dirname, '..');
 
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
-const GROQ_MODEL = 'mixtral-8x7b-32768';
-const SITE_AUTHOR = 'Liang Sun';
+const GROQ_MODEL = 'llama-3.3-70b-versatile';
+const SITE_AUTHOR = GROQ_MODEL.split('/')
+    .pop()
+    .replace(/-versatile|-instruct|-instant|-preview/g, '')
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
 
 function yamlQuote(value) {
     const escaped = String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
@@ -51,14 +56,10 @@ Requirements:
 - 300-500 words
 - Educational, practical, and technically accurate
 - Write in clear, engaging English
-- Use markdown formatting for the body (headings, lists, code blocks as needed)
-
-Respond with valid JSON only (no markdown wrapping, no trailing commas):
-{
-  "title": "The article title",
-  "description": "One-sentence summary for the post's frontmatter description",
-  "body": "Full article body in markdown format"
-}`;
+- Use markdown formatting (headings, lists, code blocks as needed)
+- Start with a level-2 heading (##) for the title
+- Do not include any JSON, metadata, or code fences around the article
+- Just write the article directly in plain markdown`;
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 60000);
@@ -89,23 +90,18 @@ Respond with valid JSON only (no markdown wrapping, no trailing commas):
     }
 
     const data = await response.json();
-    const content = data.choices[0].message.content;
+    const body = data.choices[0].message.content.trim();
 
-    try {
-        const cleaned = content
-            .replace(/^```json\s*/i, '')
-            .replace(/```\s*$/, '')
-            .trim();
-        return JSON.parse(cleaned);
-    } catch {
-        const lines = content.split('\n');
-        const firstHeading = lines.find((l) => l.startsWith('# '));
-        const title = firstHeading
-            ? firstHeading.replace(/^#\s+/, '').trim()
-            : topic.title;
-        const description = topic.angle.slice(0, 150);
-        return { title, description, body: content };
-    }
+    const firstPara = body
+        .replace(/^##\s+.*\n*/i, '')
+        .split('\n\n')
+        .find((p) => p.trim().length > 0);
+
+    const description = firstPara
+        ? firstPara.replace(/[*_#]/g, '').trim().slice(0, 150)
+        : topic.angle.slice(0, 150);
+
+    return { title: topic.title, description, body };
 }
 
 function generateFrontmatter({ title, description, dateStr, tags }) {

--- a/scripts/write-post.mjs
+++ b/scripts/write-post.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import {
+    readFileSync,
+    writeFileSync,
+    existsSync,
+    mkdirSync,
+    appendFileSync,
+} from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
@@ -13,6 +19,11 @@ const REPO_ROOT = join(__dirname, '..');
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 const GROQ_MODEL = 'mixtral-8x7b-32768';
 const SITE_AUTHOR = 'Liang Sun';
+
+function yamlQuote(value) {
+    const escaped = String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    return `"${escaped}"`;
+}
 
 function getTodayDate() {
     return new Date().toISOString().slice(0, 10);
@@ -49,6 +60,9 @@ Respond with valid JSON only (no markdown wrapping, no trailing commas):
   "body": "Full article body in markdown format"
 }`;
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 60000);
+
     const response = await fetch(GROQ_API_URL, {
         method: 'POST',
         headers: {
@@ -61,10 +75,13 @@ Respond with valid JSON only (no markdown wrapping, no trailing commas):
                 { role: 'system', content: systemPrompt },
                 { role: 'user', content: userPrompt },
             ],
-            temperature: 0.7,
-            max_tokens: 1024,
+            temperature: 0.5,
+            max_tokens: 2048,
         }),
+        signal: controller.signal,
     });
+
+    clearTimeout(timeoutId);
 
     if (!response.ok) {
         const errorText = await response.text();
@@ -94,8 +111,8 @@ Respond with valid JSON only (no markdown wrapping, no trailing commas):
 function generateFrontmatter({ title, description, dateStr, tags }) {
     const tagsYaml = tags.map((t) => `  - ${t}`).join('\n');
     return `---
-title: ${title}
-description: ${description}
+title: ${yamlQuote(title)}
+description: ${yamlQuote(description)}
 pubDate: ${dateStr}
 author: ${SITE_AUTHOR}
 aiGeneratedContent: true
@@ -151,6 +168,13 @@ async function main() {
     console.log(`Generating article for: ${topic.title}`);
     const result = await callGroq(topic);
 
+    if (!result.title || !result.description || !result.body) {
+        console.error(
+            'AI response missing required fields (title, description, or body).',
+        );
+        process.exit(1);
+    }
+
     if (!existsSync(POSTS_DIR)) {
         mkdirSync(POSTS_DIR, { recursive: true });
     }
@@ -177,6 +201,10 @@ async function main() {
         console.log('Formatted with prettier');
     } catch {
         console.warn('Prettier formatting skipped (non-fatal)');
+    }
+
+    if (process.env.GITHUB_OUTPUT) {
+        appendFileSync(process.env.GITHUB_OUTPUT, `topic-slug=${topic.slug}\n`);
     }
 }
 

--- a/scripts/write-post.mjs
+++ b/scripts/write-post.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TOPICS_PATH = join(__dirname, 'topics.json');
+const POSTS_DIR = join(__dirname, '..', 'src', 'content', 'posts');
+const REPO_ROOT = join(__dirname, '..');
+
+const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
+const GROQ_MODEL = 'mixtral-8x7b-32768';
+const SITE_AUTHOR = 'Liang Sun';
+
+function getTodayDate() {
+    return new Date().toISOString().slice(0, 10);
+}
+
+function readTopics() {
+    const raw = readFileSync(TOPICS_PATH, 'utf-8');
+    return JSON.parse(raw);
+}
+
+function writeTopics(topics) {
+    writeFileSync(TOPICS_PATH, JSON.stringify(topics, null, 4) + '\n');
+}
+
+async function callGroq(topic) {
+    const systemPrompt =
+        'You are a technical blog writer for a personal portfolio site. Write concise, engaging blog posts about AI in web engineering for a seasoned full-stack web engineer audience.';
+
+    const userPrompt = `Write a blog post about: ${topic.title}
+
+Angle: ${topic.angle}
+Tags: ${topic.tags.join(', ')}
+
+Requirements:
+- 300-500 words
+- Educational, practical, and technically accurate
+- Write in clear, engaging English
+- Use markdown formatting for the body (headings, lists, code blocks as needed)
+
+Respond with valid JSON only (no markdown wrapping, no trailing commas):
+{
+  "title": "The article title",
+  "description": "One-sentence summary for the post's frontmatter description",
+  "body": "Full article body in markdown format"
+}`;
+
+    const response = await fetch(GROQ_API_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+        },
+        body: JSON.stringify({
+            model: GROQ_MODEL,
+            messages: [
+                { role: 'system', content: systemPrompt },
+                { role: 'user', content: userPrompt },
+            ],
+            temperature: 0.7,
+            max_tokens: 1024,
+        }),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Groq API error (${response.status}): ${errorText}`);
+    }
+
+    const data = await response.json();
+    const content = data.choices[0].message.content;
+
+    try {
+        const cleaned = content
+            .replace(/^```json\s*/i, '')
+            .replace(/```\s*$/, '')
+            .trim();
+        return JSON.parse(cleaned);
+    } catch {
+        const lines = content.split('\n');
+        const firstHeading = lines.find((l) => l.startsWith('# '));
+        const title = firstHeading
+            ? firstHeading.replace(/^#\s+/, '').trim()
+            : topic.title;
+        const description = topic.angle.slice(0, 150);
+        return { title, description, body: content };
+    }
+}
+
+function generateFrontmatter({ title, description, dateStr, tags }) {
+    const tagsYaml = tags.map((t) => `  - ${t}`).join('\n');
+    return `---
+title: ${title}
+description: ${description}
+pubDate: ${dateStr}
+author: ${SITE_AUTHOR}
+aiGeneratedContent: true
+draft: true
+tags:
+${tagsYaml}
+---
+`;
+}
+
+function slugToFileName(dateStr, slug) {
+    return `${dateStr}-${slug}.md`;
+}
+
+async function main() {
+    const topicSlug = process.argv[2];
+    const topics = readTopics();
+
+    let topicIndex;
+    let topic;
+
+    if (topicSlug) {
+        topicIndex = topics.findIndex((t) => t.slug === topicSlug);
+        if (topicIndex === -1) {
+            console.error(`Topic "${topicSlug}" not found.`);
+            process.exit(1);
+        }
+        topic = topics[topicIndex];
+        if (topic.usedAt) {
+            console.error(
+                `Topic "${topicSlug}" was already used on ${topic.usedAt}.`,
+            );
+            process.exit(1);
+        }
+    } else {
+        topicIndex = topics.findIndex((t) => !t.usedAt);
+        if (topicIndex === -1) {
+            console.log('All topics have been used. No article to generate.');
+            process.exit(0);
+        }
+        topic = topics[topicIndex];
+    }
+
+    const dateStr = getTodayDate();
+    const fileName = slugToFileName(dateStr, topic.slug);
+    const filePath = join(POSTS_DIR, fileName);
+
+    if (existsSync(filePath)) {
+        console.error(`File already exists: ${fileName}`);
+        process.exit(1);
+    }
+
+    console.log(`Generating article for: ${topic.title}`);
+    const result = await callGroq(topic);
+
+    if (!existsSync(POSTS_DIR)) {
+        mkdirSync(POSTS_DIR, { recursive: true });
+    }
+
+    const frontmatter = generateFrontmatter({
+        title: result.title,
+        description: result.description,
+        dateStr,
+        tags: topic.tags,
+    });
+    const content = frontmatter + result.body.trimEnd() + '\n';
+    writeFileSync(filePath, content);
+    console.log(`Written: ${filePath}`);
+
+    topic.usedAt = dateStr;
+    writeTopics(topics);
+    console.log(`Updated topic queue: ${topic.slug} marked as used`);
+
+    try {
+        execSync(`npx prettier --write "${filePath}"`, {
+            cwd: REPO_ROOT,
+            stdio: 'inherit',
+        });
+        console.log('Formatted with prettier');
+    } catch {
+        console.warn('Prettier formatting skipped (non-fatal)');
+    }
+}
+
+main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+});

--- a/src/components/sections/pageSection.astro
+++ b/src/components/sections/pageSection.astro
@@ -19,6 +19,11 @@ const containerClasses =
     layout === 'grid'
         ? 'container mx-auto grid min-h-screen sm:border-r sm:border-l sm:border-stone-200'
         : 'container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200';
+
+const bottomTextClasses =
+    layout === 'grid'
+        ? 'justify-self-end p-4 text-black/60 hover:text-black/70'
+        : 'self-end p-4 text-black/60 hover:text-black/70';
 ---
 
 <section class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20">
@@ -35,10 +40,7 @@ const containerClasses =
         </div>
         {
             bottomHref && (
-                <a
-                    href={bottomHref}
-                    class="self-end p-4 text-black/60 hover:text-black/70"
-                >
+                <a href={bottomHref} class={bottomTextClasses}>
                     {bottomText}
                 </a>
             )


### PR DESCRIPTION
Adds a scheduled GitHub Actions workflow that generates AI blog posts twice a week using Groq (free tier), creates a PR with `draft: true` posts for human review.

## Changes

- **`.github/workflows/blog-writer.yml`** — Biweekly cron (Mon+Thu @ 09:00 UTC) + manual trigger via `workflow_dispatch` with optional `topic_slug` input. Runs generation → Prettier check → `astro check` → `astro build` → creates PR.
- **`scripts/write-post.mjs`** — ESM script that reads `topics.json`, calls Groq (`mixtral-8x7b-32768`) via native `fetch`, writes post to `src/content/posts/` with `draft: true` / `aiGeneratedContent: true`, and updates the topic queue.
- **`scripts/topics.json`** — 10 curated topics focused on AI in web engineering, agentic coding, and developer workflows.

## Setup Required

- Add `GROQ_API_KEY` repository secret

## Verification

- `prettier --check` ✅
- `npm run check` ✅ (0 errors)
- `npm run build` ✅ (25 pages)

Ref: LYO-54