### PR TITLE
fix: render date client-side in hero to avoid cache busting

### DIFF
--- a/src/components/sections/hero.astro
+++ b/src/components/sections/hero.astro
@@ -1,8 +1,6 @@
 ---
 import ExternalLink from '../atoms/externalLink.astro';
 import PageSection from './pageSection.astro';
-
-const currentDate = new Date().toDateString();
 ---
 
 <PageSection
@@ -39,6 +37,13 @@ const currentDate = new Date().toDateString();
         </li>
     </ul>
     <div slot="bottom" class="justify-self-end p-4 text-black/60">
-        {currentDate}
+        <span id="current-date"></span>
     </div>
 </PageSection>
+
+<script>
+    const el = document.getElementById('current-date');
+    if (el) {
+        el.textContent = new Date().toDateString();
+    }
+</script>


### PR DESCRIPTION
## Summary

Replaces server-rendered `new Date().toDateString()` in hero with a client-side inline script.

**Before:** `const currentDate = new Date().toDateString()` rendered into HTML at build time — changed on every build, busting CDN cache.

**After:** Empty `<span id="current-date">` in server HTML, populated by inline `<script>` on the client. Server output stays stable across builds.

Ref: LYO-32