### PR TITLE
feat(a11y): add skip-to-content navigation link

### DIFF
--- a/src/components/atoms/skipLink.astro
+++ b/src/components/atoms/skipLink.astro
@@ -1,5 +1,1 @@
----
-
----
-
 <a href="#main-content" class="skip-link">Skip to content</a>

--- a/src/components/atoms/skipLink.astro
+++ b/src/components/atoms/skipLink.astro
@@ -1,0 +1,5 @@
+---
+
+---
+
+<a href="#main-content" class="skip-link">Skip to content</a>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -1,4 +1,5 @@
 ---
+import SkipLink from '../components/atoms/skipLink.astro';
 import '../styles/global.css';
 import GA4 from '../meta/ga4.astro';
 import { ClientRouter } from 'astro:transitions';
@@ -125,7 +126,8 @@ const imageMimeType = image ? undefined : 'image/webp';
         <GA4 />
     </head>
     <body>
-        <main>
+        <SkipLink />
+        <main id="main-content">
             <slot />
         </main>
     </body>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,7 +39,7 @@ body {
 }
 
 .skip-link {
-  @apply absolute -top-full left-4 z-[9999] rounded-md bg-white px-4 py-2 text-sm font-semibold text-black shadow-lg ring-2 ring-emerald-300 transition-all duration-150 outline-none focus:top-4;
+  @apply fixed -top-full left-4 z-[9999] rounded-md bg-white px-4 py-2 text-sm font-semibold text-black shadow-lg ring-2 ring-emerald-300 transition-all duration-150 outline-none focus:top-4;
 }
 
 .line-before {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,6 +38,10 @@ body {
   @apply bg-emerald-300;
 }
 
+.skip-link {
+  @apply absolute -top-full left-4 z-[9999] rounded-md bg-white px-4 py-2 text-sm font-semibold text-black shadow-lg ring-2 ring-emerald-300 transition-all duration-150 outline-none focus:top-4;
+}
+
 .line-before {
   @apply before:absolute before:top-0 before:left-1/2 before:h-px before:w-[100vw] before:-translate-x-1/2 before:bg-stone-200;
 }


### PR DESCRIPTION
Adds a visually-hidden skip-to-content link as the first focusable element on every page, allowing keyboard and screen reader users to jump directly to main content.

**Changes:**
- New `src/components/atoms/skipLink.astro` — renders `<a href="#main-content">Skip to content</a>`
- `src/layouts/layout.astro` — added `id="main-content"` to `<main>`, imported and rendered `<SkipLink />` immediately after `<body>`
- `src/styles/global.css` — added `.skip-link` class (off-screen by default, slides into view on focus)

**Verification:**
- `npm run build` — passes
- `npm run check` — 0 errors, 0 warnings
- Built HTML confirmed on all 25 pages

Ref: LYO-30