### PR TITLE
fix(ci): append commits to blog branch instead of force push

### DIFF
--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -35,6 +35,7 @@ jobs:
             git checkout "$BRANCH"
             echo "branch_exists=true" >> "$GITHUB_OUTPUT"
           else
+            git checkout -b "$BRANCH"
             echo "branch_exists=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -20,6 +20,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup blog branch
+        id: setup
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          BRANCH="blog/${DATE}"
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "branch_name=$BRANCH" >> "$GITHUB_OUTPUT"
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+            git checkout "$BRANCH"
+            echo "branch_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch_exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -56,9 +73,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.BLOG_WRITER_PAT }}
         run: |
-          DATE=$(date +%Y-%m-%d)
-          BRANCH="blog/${DATE}"
-
           if git diff --quiet && git ls-files --others --exclude-standard --quiet; then
             echo "No changes to commit."
             exit 0
@@ -66,25 +80,19 @@ jobs:
 
           git config user.name "lyonsun"
           git config user.email "sunly917@gmail.com"
-          git checkout -b "$BRANCH"
           git add src/content/posts/ scripts/topics.json
-          git commit -m "content(posts): add new post for ${DATE}"
-          git push origin "$BRANCH" --force
+          git commit -m "content(posts): add new post for ${{ steps.setup.outputs.date }}"
+          git push origin HEAD:"${{ steps.setup.outputs.branch_name }}"
 
-          PR_EXISTS=$(gh pr list --head "$BRANCH" --json number --jq 'length')
-          if [ "$PR_EXISTS" -eq 0 ]; then
+          if [ "${{ steps.setup.outputs.branch_exists }}" = "false" ]; then
             SLUG="${{ steps.compose.outputs.topic-slug }}"
-            BODY=$(cat <<EOF
-          This PR adds an AI-generated blog post draft.
+            gh pr create \
+              --title "content(posts): add new post for ${{ steps.setup.outputs.date }}" \
+              --body "This PR adds an AI-generated blog post draft.
 
           Topic slug: ${SLUG}
 
-          **Note:** The post has \`draft: true\` and \`aiGeneratedContent: true\`. Review and remove \`draft: true\` before publishing.
-          EOF
-          )
-            gh pr create \
-              --title "content(posts): add new post for ${DATE}" \
-              --body "$BODY"
+          **Note:** The post has \`draft: true\` and \`aiGeneratedContent: true\`. Review and remove \`draft: true\` before publishing."
           else
-            echo "PR already exists for branch $BRANCH."
+            echo "PR already exists for this branch."
           fi

--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -78,7 +78,7 @@ jobs:
             exit 0
           fi
 
-          git config user.name "lyonsun"
+          git config user.name "Liang Sun"
           git config user.email "sunly917@gmail.com"
           git add src/content/posts/ scripts/topics.json
           git commit -m "content(posts): add new post for ${{ steps.setup.outputs.date }}"


### PR DESCRIPTION
The blog writer workflow was force-pushing to `blog/YYYY-MM-DD`, which overwrites any manual changes on the same branch.

Now it checks if the branch exists first and appends a new commit instead.

Ref: PR #74 review cycle