### PR TITLE
fix(ci): revise existing post on re-run instead of creating new one

### DIFF
--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -49,6 +49,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Compose blog post
+        if: steps.setup.outputs.branch_exists == 'false'
         id: compose
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
@@ -59,6 +60,18 @@ jobs:
           else
             node scripts/write-post.mjs
           fi
+
+      - name: Revise blog post
+        if: steps.setup.outputs.branch_exists == 'true'
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        run: |
+          POST_FILE=$(ls src/content/posts/${{ steps.setup.outputs.date }}-*.md 2>/dev/null | head -1)
+          if [ -z "$POST_FILE" ]; then
+            echo "No existing post found for ${{ steps.setup.outputs.date }}."
+            exit 0
+          fi
+          node scripts/revise-post.mjs "$POST_FILE"
 
       - name: Check formatting
         run: npx prettier --check .
@@ -81,8 +94,15 @@ jobs:
 
           git config user.name "Liang Sun"
           git config user.email "sunly917@gmail.com"
-          git add src/content/posts/ scripts/topics.json
-          git commit -m "content(posts): add new post for ${{ steps.setup.outputs.date }}"
+
+          if [ "${{ steps.setup.outputs.branch_exists }}" = "false" ]; then
+            git add src/content/posts/ scripts/topics.json
+            git commit -m "content(posts): add new post for ${{ steps.setup.outputs.date }}"
+          else
+            git add src/content/posts/
+            git commit -m "content(posts): revise post for ${{ steps.setup.outputs.date }}"
+          fi
+
           git push origin HEAD:"${{ steps.setup.outputs.branch_name }}"
 
           if [ "${{ steps.setup.outputs.branch_exists }}" = "false" ]; then

--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: |
-          POST_FILE=$(ls src/content/posts/${{ steps.setup.outputs.date }}-*.md 2>/dev/null | head -1)
+          POST_FILE=$(printf '%s\n' src/content/posts/${{ steps.setup.outputs.date }}-*.md 2>/dev/null | head -1)
           if [ -z "$POST_FILE" ]; then
             echo "No existing post found for ${{ steps.setup.outputs.date }}."
             exit 0

--- a/scripts/revise-post.mjs
+++ b/scripts/revise-post.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { execSync } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
 
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 const GROQ_MODEL = 'llama-3.3-70b-versatile';
@@ -62,7 +68,9 @@ async function main() {
     const filePath = args.find((a) => !a.startsWith('--'));
 
     if (!filePath) {
-        console.error('Usage: node scripts/revise-post.mjs [--dry-run] <file-path>');
+        console.error(
+            'Usage: node scripts/revise-post.mjs [--dry-run] <file-path>',
+        );
         process.exit(1);
     }
 
@@ -77,6 +85,10 @@ async function main() {
     console.log(`Revising: ${filePath}`);
     const revisedBody = await callGroq(body);
 
+    if (!revisedBody || revisedBody.length < 50) {
+        throw new Error('Revision returned empty or too short — discarding.');
+    }
+
     if (dryRun) {
         console.log(`[dry-run] Would revise: ${filePath}`);
         console.log('--- Revised body preview (first 200 chars) ---');
@@ -85,8 +97,23 @@ async function main() {
         process.exit(0);
     }
 
-    const newContent = `---\n${frontmatter}\n---\n\n${revisedBody}\n`;
+    const today = new Date().toISOString().slice(0, 10);
+    const updatedFrontmatter = frontmatter.includes('updatedAt:')
+        ? frontmatter.replace(/updatedAt:.*/, `updatedAt: ${today}`)
+        : `${frontmatter}\nupdatedAt: ${today}`;
+
+    const newContent = `---\n${updatedFrontmatter}\n---\n\n${revisedBody}\n`;
     writeFileSync(filePath, newContent);
+
+    try {
+        execSync(`npx prettier --write "${filePath}"`, {
+            cwd: REPO_ROOT,
+            stdio: 'inherit',
+        });
+    } catch {
+        console.warn('Prettier formatting skipped (non-fatal)');
+    }
+
     console.log(`Revised: ${filePath}`);
 }
 

--- a/scripts/revise-post.mjs
+++ b/scripts/revise-post.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+
+const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
+const GROQ_MODEL = 'llama-3.3-70b-versatile';
+
+async function callGroq(postBody) {
+    const systemPrompt =
+        'You are a technical blog editor. Revise the given blog post to be more technically accurate, deeper, and clearer. Keep the same overall structure and length (300-500 words). Use JavaScript or TypeScript for all code examples. Do not change the topic or angle. Do not wrap the output in code fences. Return only the revised markdown body — no title, no metadata.';
+
+    const userPrompt = `Revise this blog post. Improve technical accuracy, add depth, fix any inaccuracies, and ensure code examples are JavaScript or TypeScript.
+
+---BEGIN POST---
+${postBody}
+---END POST---`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 60000);
+
+    const response = await fetch(GROQ_API_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+        },
+        body: JSON.stringify({
+            model: GROQ_MODEL,
+            messages: [
+                { role: 'system', content: systemPrompt },
+                { role: 'user', content: userPrompt },
+            ],
+            temperature: 0.3,
+            max_tokens: 2048,
+        }),
+        signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Groq API error (${response.status}): ${errorText}`);
+    }
+
+    const data = await response.json();
+    const revised = data.choices[0].message.content.trim();
+    return revised.replace(/^```[\w]*\n?|```$/g, '').trim();
+}
+
+function splitFrontmatter(content) {
+    const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+    if (!match) {
+        throw new Error('File is missing valid frontmatter');
+    }
+    return { frontmatter: match[1].trim(), body: match[2].trim() };
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+    const dryRun = args.includes('--dry-run');
+    const filePath = args.find((a) => !a.startsWith('--'));
+
+    if (!filePath) {
+        console.error('Usage: node scripts/revise-post.mjs [--dry-run] <file-path>');
+        process.exit(1);
+    }
+
+    if (!existsSync(filePath)) {
+        console.error(`File not found: ${filePath}`);
+        process.exit(1);
+    }
+
+    const content = readFileSync(filePath, 'utf-8');
+    const { frontmatter, body } = splitFrontmatter(content);
+
+    console.log(`Revising: ${filePath}`);
+    const revisedBody = await callGroq(body);
+
+    if (dryRun) {
+        console.log(`[dry-run] Would revise: ${filePath}`);
+        console.log('--- Revised body preview (first 200 chars) ---');
+        console.log(revisedBody.slice(0, 200));
+        console.log('---');
+        process.exit(0);
+    }
+
+    const newContent = `---\n${frontmatter}\n---\n\n${revisedBody}\n`;
+    writeFileSync(filePath, newContent);
+    console.log(`Revised: ${filePath}`);
+}
+
+main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+});


### PR DESCRIPTION
When the blog branch already exists (re-run), revise the existing post via AI instead of composing a new post about a different topic.

- New `scripts/revise-post.mjs` — reads an existing post, sends to Groq for revision (improve accuracy, depth, JS/TS examples)
- Compose step now only runs on first run (`branch_exists == false`)
- Revise step runs on re-runs (`branch_exists == true`), finds today's post by date pattern
- Commit message differs: `content(posts): add new post` vs `content(posts): revise post`

This keeps each PR focused on a single post.