### PR TITLE
fix(ci): extract revise-post.mjs from main before running

### DIFF
--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -71,7 +71,9 @@ jobs:
             echo "No existing post found for ${{ steps.setup.outputs.date }}."
             exit 0
           fi
-          node scripts/revise-post.mjs "$POST_FILE"
+          git show main:scripts/revise-post.mjs > /tmp/revise-post.mjs
+          chmod +x /tmp/revise-post.mjs
+          node /tmp/revise-post.mjs "$POST_FILE"
 
       - name: Check formatting
         run: npx prettier --check .


### PR DESCRIPTION
When the workflow checks out an existing blog branch (e.g., `blog/2026-05-27`), `scripts/revise-post.mjs` doesn't exist because the branch was created before that file was added.

Fix: extract the script from `main` via `git show main:scripts/revise-post.mjs` and run it from `/tmp`.