### PR TITLE
fix: use sentence case for post titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ src/
 
 Required frontmatter: `title`, `description`, `pubDate`. Optional: `tags` (default `[]`), `author`, `updatedAt`, `draft` (default `false`), `aiGeneratedContent` (default `false`). Schema in `src/content.config.ts`.
 
+- **Title case**: Use sentence case for all post titles (e.g., "How AI coding assistants actually work", not "How AI Coding Assistants Actually Work").
+
 ## CI / Lighthouse
 
 - **Deploy**: Push to `main` → GitHub Pages. Uses `actions/checkout@v6`, `actions/setup-node@v6`, `actions/configure-pages@v6`, `actions/deploy-pages@v5`, `actions/upload-pages-artifact@v5`.

--- a/src/content/posts/2026-05-30-how-ai-coding-assistants-work.md
+++ b/src/content/posts/2026-05-30-how-ai-coding-assistants-work.md
@@ -1,5 +1,5 @@
 ---
-title: "How AI Coding Assistants Actually Work"
+title: "How AI coding assistants actually work"
 description: "AI coding assistants have revolutionized the way we write code, providing intelligent suggestions and automating repetitive tasks."
 pubDate: 2026-05-30
 author: Meta Llama 3.3 70b


### PR DESCRIPTION
Update latest post title to sentence case and add the convention to AGENTS.md so future LLM-generated posts follow suit.