### PR TITLE
docs: document PR template workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,6 @@ Required frontmatter: `title`, `description`, `pubDate`. Optional: `tags` (defau
 - Conventional Commits: `type(scope): description`. Always create a branch per issue.
 - Branch naming: no prefix (e.g., `fix/external-link-rel`, not `lyonsun7/lyo-42-...`).
 - Pre-commit order: `new branch` → `build` → `check` → `format`, then review `git diff`.
-- After pushing, always create a PR using `gh pr create`.
+- After pushing, always create a PR: read `.github/pull_request_template.md`, fill it, and create with `gh pr create --title "..." --body "..."`.
 - No force push; never commit without explicit approval.
 - Reference Linear: `Ref: LYO-NN`.


### PR DESCRIPTION
## Summary

Document that PRs should be created by reading the template, filling it, and using `gh pr create --title "..." --body "..."`.

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes (type check)
- [x] `npm run format` applied (Prettier)
- [ ] Preview build visually checked for layout issues

## Related Issues