### PR TITLE
docs: align branch naming with commit type prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,6 @@ Required frontmatter: `title`, `description`, `pubDate`. Optional: `tags` (defau
 - Conventional Commits: `type(scope): description`. Always create a branch per issue.
 - Branch naming: no prefix (e.g., `fix/external-link-rel`, not `lyonsun7/lyo-42-...`).
 - Pre-commit order: `new branch` → `build` → `check` → `format`, then review `git diff`.
-- After pushing, always create a PR using `gh pr create`.
+- After pushing, always create a PR: read `.github/pull_request_template.md`, fill it, and create with `gh pr create --title "..." --body "..."`.
 - No force push; never commit without explicit approval.
 - Reference Linear: `Ref: LYO-NN`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Required frontmatter: `title`, `description`, `pubDate`. Optional: `tags` (defau
 ## Git Workflow
 
 - Conventional Commits: `type(scope): description`. Always create a branch per issue.
-- Branch naming: no prefix (e.g., `fix/external-link-rel`, not `lyonsun7/lyo-42-...`).
+- Branch naming: `type/scope` where `type` matches the conventional commit type (e.g., `docs/pr-template-workflow`, `fix/external-link-rel`). No user prefix like `lyonsun7/`.
 - Pre-commit order: `new branch` → `build` → `check` → `format`, then review `git diff`.
 - After pushing, always create a PR: read `.github/pull_request_template.md`, fill it, and create with `gh pr create --title "..." --body "..."`.
 - No force push; never commit without explicit approval.


### PR DESCRIPTION
## Summary

Update AGENTS.md branch naming convention to explicitly require `type/scope` where `type` matches the conventional commit type (e.g., `docs/pr-template-workflow`, `fix/external-link-rel`). Previously the rule only said "no prefix" with an example, which was ambiguous — the review bot caught a case where `fix/` branch prefix didn't match `docs:` commit type.

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes (type check)
- [x] `npm run format` applied (Prettier)
- [ ] Preview build visually checked for layout issues

## Related Issues