### PR TITLE
fix: add Story section with issue link at top

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+## Story
+
+<!-- Link to the Linear or GitHub issue. -->
+<!-- e.g. [LYO-NN](https://linear.app/lyonsun7/issue/LYO-NN) -->
+
 ## Summary
 
 <!-- Brief description of the change and what it accomplishes. -->
@@ -12,9 +17,3 @@
 - [ ] `npm run check` passes (type check)
 - [ ] `npm run format` applied (Prettier)
 - [ ] Preview build visually checked for layout issues
-
-## Related Issues
-
-<!-- Reference any Linear or GitHub issues. -->
-<!-- Linear: LYO-NN -->
-


### PR DESCRIPTION
## Story

N/A

## Summary

Moved the issue reference to the top of the PR template under a "Story" heading with a link format example, removed the old "Related Issues" section at the bottom.

## Verification

- [x] `npm run format` applied (Prettier)