### PR TITLE
feat(scripts): add LLM-powered topic generation workflow

### DIFF
--- a/.github/workflows/generate-topics.yml
+++ b/.github/workflows/generate-topics.yml
@@ -1,0 +1,74 @@
+name: Generate Topics
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Setup topics branch
+        id: setup
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          BRANCH="topics/${DATE}"
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+          echo "branch_name=$BRANCH" >> "$GITHUB_OUTPUT"
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+            echo "Branch $BRANCH already exists. Topics likely already generated today."
+            echo "branch_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate topics
+        if: steps.setup.outputs.branch_exists == 'false'
+        id: generate
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        run: node scripts/generate-topics.mjs
+
+      - name: Format topics.json
+        if: steps.generate.outputs.num-generated != '' && steps.generate.outputs.num-generated != '0'
+        run: npx prettier --write scripts/topics.json
+
+      - name: Create Pull Request
+        if: steps.generate.outputs.num-generated != '' && steps.generate.outputs.num-generated != '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.BLOG_WRITER_PAT }}
+        run: |
+          BRANCH="${{ steps.setup.outputs.branch_name }}"
+
+          git config user.name "Liang Sun"
+          git config user.email "sunly917@gmail.com"
+
+          git checkout -b "$BRANCH"
+          git add scripts/topics.json
+          git commit -m "content(posts): add ${{ steps.generate.outputs.num-generated }} new topic(s) to queue"
+
+          git push origin HEAD:"${BRANCH}"
+
+          gh pr create \
+            --title "content(posts): add ${{ steps.generate.outputs.num-generated }} new topic(s) to queue" \
+            --body "This PR adds ${{ steps.generate.outputs.num-generated }} new topic(s) to \`scripts/topics.json\`, generated via LLM.
+
+          Review the new topic ideas and merge if they look good. The \`write-post.mjs\` script will consume them on its next run."

--- a/scripts/generate-topics-prompt.md
+++ b/scripts/generate-topics-prompt.md
@@ -1,0 +1,32 @@
+You are a topic curator for a personal technical blog. Generate blog post topic ideas for a full-stack web engineer audience.
+
+# Constraints
+
+- Generate a mix of AI/LLM topics and general software engineering topics.
+- Topics must be practical, technically substantive, and worth a full blog post (300-500 words).
+- Avoid generic or overdone topics. Prioritize novel angles, emerging patterns, and concrete engineering challenges.
+- Use sentence case for titles.
+
+# Output format
+
+Return ONLY a valid JSON array of objects, each with these exact fields:
+
+- `slug`: URL-safe identifier (lowercase, hyphens, no spaces, no special chars). Must be 3-40 characters.
+- `title`: Sentence case title (e.g., "Debugging distributed systems in production").
+- `angle`: 1-2 sentence description of the specific angle or thesis for the post. Must be different from existing topics.
+- `tags`: Array of 2-4 lowercase tag strings. Reuse existing tags when appropriate; invent new ones only when necessary.
+
+Example:
+
+```json
+[
+  {
+    "slug": "debugging-distributed-systems",
+    "title": "Debugging distributed systems in production",
+    "angle": "Practical patterns for debugging distributed systems: structured logging, trace propagation, and deterministic replay. Focus on tooling that works today.",
+    "tags": ["architecture", "debugging", "distributed-systems"]
+  }
+]
+```
+
+Do not wrap the output in any enclosing text. Return only the JSON array.

--- a/scripts/generate-topics.mjs
+++ b/scripts/generate-topics.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, readdirSync, appendFileSync } from 'fs';
+import { join, dirname, extname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROMPT_PATH = join(__dirname, 'generate-topics-prompt.md');
+const TOPICS_PATH = join(__dirname, 'topics.json');
+const POSTS_DIR = join(__dirname, '..', 'src', 'content', 'posts');
+
+const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
+const GROQ_MODEL = 'llama-3.3-70b-versatile';
+const TARGET_UNUSED = 10;
+
+function readTopics() {
+    const raw = readFileSync(TOPICS_PATH, 'utf-8');
+    return JSON.parse(raw);
+}
+
+function writeTopics(topics) {
+    writeFileSync(TOPICS_PATH, JSON.stringify(topics, null, 4) + '\n');
+}
+
+function getPostSlugs() {
+    const files = readdirSync(POSTS_DIR);
+    return files
+        .filter((f) => f.endsWith('.md'))
+        .map((f) => (extname(f) ? f.replace(extname(f), '') : f))
+        .map((slug) => {
+            const match = slug.match(/^\d{4}-\d{2}-\d{2}-(.+)/);
+            return match ? match[1] : slug;
+        });
+}
+
+function buildExistingContext(topics, postSlugs) {
+    const used = topics.filter((t) => t.usedAt);
+    const unused = topics.filter((t) => !t.usedAt);
+
+    const lines = [];
+    lines.push('Existing topic titles (already used):');
+    used.forEach((t) => lines.push(`  - ${t.title}`));
+    lines.push('Existing topic titles (unused — avoid these):');
+    unused.forEach((t) => lines.push(`  - ${t.title}`));
+    lines.push('Existing post slugs (avoid these):');
+    postSlugs.forEach((s) => lines.push(`  - ${s}`));
+    return lines.join('\n');
+}
+
+function validateTopic(topic, index) {
+    if (!topic.slug || typeof topic.slug !== 'string') {
+        throw new Error(`Topic ${index}: missing or invalid "slug"`);
+    }
+    if (!/^[a-z0-9-]{3,40}$/.test(topic.slug)) {
+        throw new Error(
+            `Topic ${index}: slug "${topic.slug}" invalid — use lowercase, hyphens, 3-40 chars`,
+        );
+    }
+    if (!topic.title || typeof topic.title !== 'string') {
+        throw new Error(`Topic ${index}: missing or invalid "title"`);
+    }
+    if (!topic.angle || typeof topic.angle !== 'string') {
+        throw new Error(`Topic ${index}: missing or invalid "angle"`);
+    }
+    if (
+        !Array.isArray(topic.tags) ||
+        topic.tags.length === 0 ||
+        !topic.tags.every((t) => typeof t === 'string')
+    ) {
+        throw new Error(
+            `Topic ${index}: "tags" must be a non-empty array of strings`,
+        );
+    }
+}
+
+function isDuplicate(topic, existingTopics, postSlugs) {
+    const slugMatch = existingTopics.some((t) => t.slug === topic.slug);
+    const titleMatch = existingTopics.some(
+        (t) => t.title.toLowerCase() === topic.title.toLowerCase(),
+    );
+    const angleMatch = existingTopics.some(
+        (t) =>
+            t.angle.toLowerCase().trim() === topic.angle.toLowerCase().trim(),
+    );
+    const postSlugMatch = postSlugs.includes(topic.slug);
+    return slugMatch || titleMatch || angleMatch || postSlugMatch;
+}
+
+async function callGroq(count, existingContext) {
+    const systemPrompt = readFileSync(PROMPT_PATH, 'utf-8').trim();
+    const userPrompt = `Generate ${count} new blog post topics for my personal tech blog.
+
+${existingContext}
+
+No duplicates. No topics about crypto, blockchain, or mobile development.`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 60000);
+
+    const response = await fetch(GROQ_API_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+        },
+        body: JSON.stringify({
+            model: GROQ_MODEL,
+            messages: [
+                { role: 'system', content: systemPrompt },
+                { role: 'user', content: userPrompt },
+            ],
+            temperature: 0.7,
+            max_tokens: 2048,
+        }),
+        signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Groq API error (${response.status}): ${errorText}`);
+    }
+
+    const data = await response.json();
+    const content = data.choices[0].message.content.trim();
+
+    let topics;
+    try {
+        topics = JSON.parse(content);
+    } catch {
+        const jsonMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
+        if (jsonMatch) {
+            topics = JSON.parse(jsonMatch[1].trim());
+        } else {
+            throw new Error('Failed to parse JSON from LLM response');
+        }
+    }
+
+    if (!Array.isArray(topics)) {
+        throw new Error('LLM response is not an array');
+    }
+
+    return topics;
+}
+
+async function main() {
+    const dryRun = process.argv.includes('--dry-run');
+    const topics = readTopics();
+    const postSlugs = getPostSlugs();
+
+    const unusedTopics = topics.filter((t) => !t.usedAt);
+    const countNeeded = TARGET_UNUSED - unusedTopics.length;
+
+    if (countNeeded <= 0) {
+        console.log(
+            `Queue has ${unusedTopics.length} unused topics (target: ${TARGET_UNUSED}). No new topics needed.`,
+        );
+        process.exit(0);
+    }
+
+    console.log(
+        `Queue has ${unusedTopics.length} unused topics. Generating ${countNeeded} new topic(s).`,
+    );
+
+    const existingContext = buildExistingContext(topics, postSlugs);
+    const generated = await callGroq(countNeeded, existingContext);
+
+    const added = [];
+    for (let i = 0; i < generated.length; i++) {
+        const topic = generated[i];
+        try {
+            validateTopic(topic, i);
+        } catch (err) {
+            console.error(`  Skipping invalid topic: ${err.message}`);
+            continue;
+        }
+        if (isDuplicate(topic, topics, postSlugs)) {
+            console.log(
+                `  Skipping duplicate: "${topic.title}" (${topic.slug})`,
+            );
+            continue;
+        }
+        topics.push({
+            slug: topic.slug,
+            title: topic.title,
+            angle: topic.angle,
+            tags: topic.tags,
+            usedAt: null,
+        });
+        added.push(topic);
+    }
+
+    if (added.length === 0) {
+        console.log('No valid new topics generated.');
+        process.exit(0);
+    }
+
+    const finalCount = topics.filter((t) => !t.usedAt).length;
+
+    if (dryRun) {
+        console.log(
+            `[dry-run] Would add ${added.length} topic(s). Final unused: ${finalCount}.`,
+        );
+        for (const t of added) {
+            console.log(`  + ${t.title} [${t.tags.join(', ')}]`);
+        }
+        process.exit(0);
+    }
+
+    writeTopics(topics);
+    console.log(
+        `Added ${added.length} topic(s). Queue now has ${finalCount} unused topics.`,
+    );
+    for (const t of added) {
+        console.log(`  + ${t.title} [${t.tags.join(', ')}]`);
+    }
+
+    if (process.env.GITHUB_OUTPUT) {
+        appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `num-generated=${added.length}\n`,
+        );
+    }
+}
+
+main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+});


### PR DESCRIPTION
## Story

[LYO-56](https://linear.app/lyonsun7/issue/LYO-56/llm-powered-topic-repopulation-workflow)

## Summary

Add a weekly scheduled workflow that uses Groq to repopulate `scripts/topics.json` with new blog post topic ideas when the queue runs low (< 10 unused).

| File | Purpose |
|---|---|
| `scripts/generate-topics-prompt.md` | System prompt for topic generation via Groq |
| `scripts/generate-topics.mjs` | Script: checks queue, calls Groq, validates & appends topics |
| `.github/workflows/generate-topics.yml` | Weekly cron (Mon 9AM UTC) + manual trigger, opens PR |

Key design decisions:
- Same Groq model (`llama-3.3-70b-versatile`) as `write-post.mjs`
- Same PR pattern as `blog-writer.yml` (direct `gh pr create`, no third-party action)
- Dedup against both existing topics and published post slugs
- Branch-existence check prevents duplicate runs on the same day

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes (type check)
- [x] `npm run format` applied (Prettier)