### PR TITLE
refactor(scripts): rename generate-topics to topic-advisor

### DIFF
--- a/.github/workflows/topic-advisor.yml
+++ b/.github/workflows/topic-advisor.yml
@@ -1,4 +1,4 @@
-name: Generate Topics
+name: Topic Advisor
 
 on:
   schedule:
@@ -40,19 +40,19 @@ jobs:
             echo "branch_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Generate topics
+      - name: Run topic advisor
         if: steps.setup.outputs.branch_exists == 'false'
         id: generate
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-        run: node scripts/generate-topics.mjs
+        run: node scripts/topic-advisor.mjs
 
       - name: Format topics.json
-        if: steps.generate.outputs.num-generated != '' && steps.generate.outputs.num-generated != '0'
+        if: steps.generate.outputs.topics-added != '' && steps.generate.outputs.topics-added != '0'
         run: npx prettier --write scripts/topics.json
 
       - name: Create Pull Request
-        if: steps.generate.outputs.num-generated != '' && steps.generate.outputs.num-generated != '0'
+        if: steps.generate.outputs.topics-added != '' && steps.generate.outputs.topics-added != '0'
         env:
           GITHUB_TOKEN: ${{ secrets.BLOG_WRITER_PAT }}
         run: |
@@ -63,12 +63,10 @@ jobs:
 
           git checkout -b "$BRANCH"
           git add scripts/topics.json
-          git commit -m "content(posts): add ${{ steps.generate.outputs.num-generated }} new topic(s) to queue"
+          git commit -m "content(posts): add ${{ steps.generate.outputs.topics-added }} new topic(s) to queue"
 
           git push origin HEAD:"${BRANCH}"
 
           gh pr create \
-            --title "content(posts): add ${{ steps.generate.outputs.num-generated }} new topic(s) to queue" \
-            --body "This PR adds ${{ steps.generate.outputs.num-generated }} new topic(s) to \`scripts/topics.json\`, generated via LLM.
-
-          Review the new topic ideas and merge if they look good. The \`write-post.mjs\` script will consume them on its next run."
+            --title "content(posts): add ${{ steps.generate.outputs.topics-added }} new topic(s) to queue" \
+            --body "${{ steps.generate.outputs.pr-body }}"

--- a/scripts/topic-advisor-prompt.md
+++ b/scripts/topic-advisor-prompt.md
@@ -1,8 +1,8 @@
-You are a topic curator for a personal technical blog. Generate blog post topic ideas for a full-stack web engineer audience.
+You are a topic advisor for a personal technical blog. Your role is to strategically recommend blog post topics that will resonate with a full-stack web engineer audience.
 
 # Constraints
 
-- Generate a mix of AI/LLM topics and general software engineering topics.
+- Recommend a mix of AI/LLM topics and general software engineering topics.
 - Topics must be practical, technically substantive, and worth a full blog post (300-500 words).
 - Avoid generic or overdone topics. Prioritize novel angles, emerging patterns, and concrete engineering challenges.
 - Use sentence case for titles.
@@ -14,6 +14,7 @@ Return ONLY a valid JSON array of objects, each with these exact fields:
 - `slug`: URL-safe identifier (lowercase, hyphens, no spaces, no special chars). Must be 3-40 characters.
 - `title`: Sentence case title (e.g., "Debugging distributed systems in production").
 - `angle`: 1-2 sentence description of the specific angle or thesis for the post. Must be different from existing topics.
+- `rationale`: 1-2 sentences explaining why this topic is worth writing now — what makes it timely, what gap it fills, or why readers will care.
 - `tags`: Array of 2-4 lowercase tag strings. Reuse existing tags when appropriate; invent new ones only when necessary.
 
 Example:
@@ -24,6 +25,7 @@ Example:
     "slug": "debugging-distributed-systems",
     "title": "Debugging distributed systems in production",
     "angle": "Practical patterns for debugging distributed systems: structured logging, trace propagation, and deterministic replay. Focus on tooling that works today.",
+    "rationale": "Distributed debugging is the #1 pain point I hear from readers. OpenTelemetry adoption is finally making trace propagation accessible, and this post captures what works in practice.",
     "tags": ["architecture", "debugging", "distributed-systems"]
   }
 ]

--- a/scripts/topic-advisor.mjs
+++ b/scripts/topic-advisor.mjs
@@ -5,7 +5,7 @@ import { join, dirname, extname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PROMPT_PATH = join(__dirname, 'generate-topics-prompt.md');
+const PROMPT_PATH = join(__dirname, 'topic-advisor-prompt.md');
 const TOPICS_PATH = join(__dirname, 'topics.json');
 const POSTS_DIR = join(__dirname, '..', 'src', 'content', 'posts');
 
@@ -61,6 +61,9 @@ function validateTopic(topic, index) {
     }
     if (!topic.angle || typeof topic.angle !== 'string') {
         throw new Error(`Topic ${index}: missing or invalid "angle"`);
+    }
+    if (!topic.rationale || typeof topic.rationale !== 'string') {
+        throw new Error(`Topic ${index}: missing or invalid "rationale"`);
     }
     if (
         !Array.isArray(topic.tags) ||
@@ -185,6 +188,7 @@ async function main() {
             slug: topic.slug,
             title: topic.title,
             angle: topic.angle,
+            rationale: topic.rationale,
             tags: topic.tags,
             usedAt: null,
         });
@@ -219,7 +223,23 @@ async function main() {
     if (process.env.GITHUB_OUTPUT) {
         appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `num-generated=${added.length}\n`,
+            `topics-added=${added.length}\n`,
+        );
+
+        const prBodyLines = [
+            `This PR adds ${added.length} new topic(s) to the queue, generated via LLM.`,
+            '',
+            '## New topics',
+            ...added.map((t) => `- **${t.title}** — ${t.rationale}`),
+            '',
+            'Review the new topic ideas and merge if they look good.',
+            'The `write-post.mjs` script will consume them on its next run.',
+        ];
+        const prBody = prBodyLines.join('\n');
+
+        appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `pr-body<<GH_TOPIC_EOF\n${prBody}\nGH_TOPIC_EOF\n`,
         );
     }
 }

--- a/scripts/write-post-prompt.md
+++ b/scripts/write-post-prompt.md
@@ -1,5 +1,7 @@
 You are a technical blog writer for a personal portfolio site. Write concise, engaging blog posts about AI in web engineering for a seasoned full-stack web engineer audience. Prioritize technical accuracy and depth — explain mechanisms, not just concepts. Use JavaScript or TypeScript for all code examples.
 
+When a topic includes a rationale, keep it in mind as the strategic reason the topic was chosen — let it guide your angle and emphasis, but don't repeat it verbatim.
+
 # Content structure
 
 Write each post following this structure:

--- a/scripts/write-post.mjs
+++ b/scripts/write-post.mjs
@@ -84,10 +84,14 @@ function writeTopics(topics) {
 async function callGroq(topic) {
     const systemPrompt = readFileSync(PROMPT_PATH, 'utf-8').trim();
 
+    const rationaleLines = topic.rationale
+        ? `\nRationale: ${topic.rationale}`
+        : '';
+
     const userPrompt = `Write a blog post about: ${topic.title}
 
 Angle: ${topic.angle}
-Tags: ${topic.tags.join(', ')}
+Tags: ${topic.tags.join(', ')}${rationaleLines}
 
 Requirements:
 - 300-500 words


### PR DESCRIPTION
Rename the topic generation workflow from "Generate Topics" to **Topic Advisor** — a more strategic, advisory role that better reflects what the system does.

## Changes

### Renames
| Before | After |
|---|---|
| `scripts/generate-topics.mjs` | `scripts/topic-advisor.mjs` |
| `scripts/generate-topics-prompt.md` | `scripts/topic-advisor-prompt.md` |
| `.github/workflows/generate-topics.yml` | `.github/workflows/topic-advisor.yml` |
| CI output `num-generated` | `topics-added` |

### Prompt refresh (`topic-advisor-prompt.md`)
- Persona: "topic advisor" (not "topic curator")
- New `rationale` field — each topic includes 1-2 sentences explaining why it's worth writing now
- Schema validated on write; existing topics without `rationale` accepted as-is

### PR body upgrade
- PR descriptions now list each new topic with its rationale, making review more informative

### Downstream updates
- `write-post.mjs` passes `topic.rationale` as additional context to the LLM when composing
- `write-post-prompt.md` hints the writer to consider the rationale as strategic guidance

Ref: LYO-NN