### PR TITLE
ci(deploy): add npm run check before build

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -70,6 +70,9 @@ jobs:
         if: steps.detect-package-manager.outputs.manager == 'npm'
         run: npm audit --audit-level=high --omit=dev
         working-directory: ${{ env.BUILD_PATH }}
+      - name: Run type check
+        run: ${{ steps.detect-package-manager.outputs.runner }} astro check
+        working-directory: ${{ env.BUILD_PATH }}
       - name: Build with Astro
         run: |
           ${{ steps.detect-package-manager.outputs.runner }} astro build \


### PR DESCRIPTION
## Story

[LYO-44](https://linear.app/lyonsun7/issue/LYO-44/add-npm-run-check-to-ci-deploy-workflow)

## Summary

Adds a type check step (`npm run check` / `astro check`) to the deploy workflow, running before the build step. This catches type errors in CI before they get deployed to GitHub Pages.

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes (type check)
- [x] `npm run format` applied (Prettier)