### PR TITLE
feat: add JSON-LD structured data for rich search results

### DIFF
--- a/src/layouts/blogPost.astro
+++ b/src/layouts/blogPost.astro
@@ -3,6 +3,7 @@ import { type CollectionEntry } from 'astro:content';
 import { formatDate } from '../lib/posts';
 import TagLink from '../components/atoms/tagLink.astro';
 import Layout from './layout.astro';
+import { SITE_AUTHOR } from '../consts';
 
 type Props = {
     frontmatter: CollectionEntry<'posts'>['data'];
@@ -14,6 +15,7 @@ const publishDate = formatDate(frontmatter.pubDate);
 const updatedDate = frontmatter.updatedAt
     ? formatDate(frontmatter.updatedAt)
     : undefined;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <Layout
@@ -77,4 +79,23 @@ const updatedDate = frontmatter.updatedAt
             </a>
         </div>
     </section>
+    <script
+        type="application/ld+json"
+        is:inline
+        set:html={JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BlogPosting',
+            headline: frontmatter.title,
+            description: frontmatter.description,
+            datePublished: frontmatter.pubDate.toISOString(),
+            dateModified: (
+                frontmatter.updatedAt ?? frontmatter.pubDate
+            ).toISOString(),
+            author: {
+                '@type': 'Person',
+                name: frontmatter.author ?? SITE_AUTHOR,
+            },
+            url: canonicalUrl,
+        })}
+    />
 </Layout>

--- a/src/layouts/blogPost.astro
+++ b/src/layouts/blogPost.astro
@@ -16,6 +16,24 @@ const updatedDate = frontmatter.updatedAt
     ? formatDate(frontmatter.updatedAt)
     : undefined;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
+
+const blogPostingStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: frontmatter.title,
+    description: frontmatter.description,
+    datePublished: frontmatter.pubDate.toISOString(),
+    dateModified: (frontmatter.updatedAt ?? frontmatter.pubDate).toISOString(),
+    author: {
+        '@type': 'Person',
+        name: frontmatter.author ?? SITE_AUTHOR,
+    },
+    url: canonicalUrl,
+    mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': canonicalUrl,
+    },
+};
 ---
 
 <Layout
@@ -25,6 +43,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
         publishedTime: frontmatter.pubDate.toISOString(),
         author: frontmatter.author,
     }}
+    structuredData={blogPostingStructuredData}
 >
     <section
         class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20"
@@ -79,23 +98,4 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
             </a>
         </div>
     </section>
-    <script
-        type="application/ld+json"
-        is:inline
-        set:html={JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'BlogPosting',
-            headline: frontmatter.title,
-            description: frontmatter.description,
-            datePublished: frontmatter.pubDate.toISOString(),
-            dateModified: (
-                frontmatter.updatedAt ?? frontmatter.pubDate
-            ).toISOString(),
-            author: {
-                '@type': 'Person',
-                name: frontmatter.author ?? SITE_AUTHOR,
-            },
-            url: canonicalUrl,
-        })}
-    />
 </Layout>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -124,6 +124,32 @@ const imageMimeType = image ? undefined : 'image/webp';
         <ClientRouter />
 
         <GA4 />
+
+        <script
+            type="application/ld+json"
+            is:inline
+            set:html={JSON.stringify({
+                '@context': 'https://schema.org',
+                '@graph': [
+                    {
+                        '@type': 'Person',
+                        name: SITE_NAME,
+                        url: new URL('/', Astro.site).toString(),
+                        sameAs: [
+                            'https://www.linkedin.com/in/lyonsun7',
+                            'https://github.com/lyonsun',
+                            `https://twitter.com/${TWITTER_HANDLE.replace('@', '')}`,
+                        ],
+                    },
+                    {
+                        '@type': 'WebSite',
+                        name: SITE_NAME,
+                        url: new URL('/', Astro.site).toString(),
+                        description: SITE_DESCRIPTION,
+                    },
+                ],
+            })}
+        />
     </head>
     <body>
         <SkipLink />

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -22,6 +22,7 @@ type Props = {
         author?: string;
     };
     noindex?: boolean;
+    structuredData?: Record<string, unknown>;
 };
 
 const {
@@ -30,6 +31,7 @@ const {
     image,
     article,
     noindex = false,
+    structuredData,
 } = Astro.props;
 
 const pageTitle = title ? title : SITE_NAME;
@@ -150,6 +152,16 @@ const imageMimeType = image ? undefined : 'image/webp';
                 ],
             })}
         />
+
+        {
+            structuredData && (
+                <script
+                    type="application/ld+json"
+                    is:inline
+                    set:html={JSON.stringify(structuredData)}
+                />
+            )
+        }
     </head>
     <body>
         <SkipLink />


### PR DESCRIPTION
## Story

[LYO-31](https://linear.app/lyonsun7/issue/LYO-31)

## Summary

Adds JSON-LD structured data to improve SEO and enable rich search results:
- `Person` + `WebSite` schemas in `layout.astro` (every page)
- `BlogPosting` schema in `blogPost.astro` (per article)

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes (type check)
- [x] `npm run format` applied (Prettier)
- [ ] Preview build visually checked for layout issues