### PR TITLE
fix(ci): use PAT for git push in blog writer workflow

### DIFF
--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -107,6 +107,7 @@ jobs:
             git commit -m "content(posts): revise post for ${{ steps.setup.outputs.date }}"
           fi
 
+          git remote set-url origin https://x-access-token:${{ secrets.BLOG_WRITER_PAT }}@github.com/lyonsun/lyonsun.github.io
           git push origin HEAD:"${{ steps.setup.outputs.branch_name }}"
 
           if [ "${{ steps.setup.outputs.branch_exists }}" = "false" ]; then


### PR DESCRIPTION
## Summary

The blog-writer workflow was pushing revision commits using the default `GITHUB_TOKEN`, attributing them to `github-actions[bot]`. This caused the downstream PR review workflow to fail with a permissions error when triggered by a `synchronize` event from the bot.

By setting the git remote URL to use `BLOG_WRITER_PAT` before pushing, the revision commits are attributed to `lyonsun`, giving the review workflow proper write permissions.

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes (type check)
- [x] `npm run format` applied (Prettier)