### PR TITLE
chore(scripts): encode PR review learnings into blog writer workflow

### DIFF
--- a/.github/workflows/blog-writer.yml
+++ b/.github/workflows/blog-writer.yml
@@ -62,7 +62,6 @@ jobs:
           fi
 
       - name: Revise blog post
-        if: steps.setup.outputs.branch_exists == 'true'
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: |

--- a/scripts/revise-post-prompt.md
+++ b/scripts/revise-post-prompt.md
@@ -9,5 +9,7 @@ You are a technical blog editor. Revise the given blog post to be more technical
 # Style rules
 
 - All code examples must use ESM/import syntax (not CommonJS require).
+- Code examples must use correct constructor and API patterns from the actual SDKs. For example, `@langchain/core`'s `PromptTemplate` requires `PromptTemplate.fromTemplate(...)`, not `new PromptTemplate(templateString)`.
+- Use sentence case for all section headings (e.g., "## How it works", not "## how it works").
 - Avoid patterns with obvious security issues (shell injection via exec, etc.).
 - Do not wrap the output in code fences.

--- a/scripts/write-post-prompt.md
+++ b/scripts/write-post-prompt.md
@@ -17,10 +17,15 @@ Write each post following this structure:
 
 4. Closing (2–3 sentences). Give a practical takeaway. Start simple, compose patterns, add complexity only when needed. Do not repeat the introduction.
 
+5. Description. Start your response with `<description>...</description>` on its own line — a standalone complete sentence (max 150 characters) that describes the post. This will be used as the SEO meta description and must NOT repeat the post title. Then a blank line, then the post body.
+
 # Style rules
 
 - Avoid filler phrases: "has the potential to", "in today's world", "revolutionize", "game-changer", "cutting-edge", "increasingly".
 - Use sentence case for the title (first word capitalized, rest lowercase unless proper nouns).
+- Use sentence case for all section headings (e.g., "## How it works", not "## how it works").
+- Section headings must be distinct from the post title. Do not mirror or paraphrase the title as a heading.
 - All code examples must use ESM/import syntax (not CommonJS require).
+- Code examples must use correct constructor and API patterns from the actual SDKs. For example, `@langchain/core`'s `PromptTemplate` requires `PromptTemplate.fromTemplate(...)`, not `new PromptTemplate(templateString)`.
 - Avoid patterns with obvious security issues (shell injection via exec, etc.).
 - Write directly in markdown. Do not wrap the output in JSON, code fences, or any enclosing structure.

--- a/scripts/write-post.mjs
+++ b/scripts/write-post.mjs
@@ -129,15 +129,24 @@ Requirements:
     }
 
     const data = await response.json();
-    const body = data.choices[0].message.content
+    const raw = data.choices[0].message.content
         .replace(/^```[\w]*\n?|```$/g, '')
         .trim();
 
-    const firstPara = body.split('\n\n').find((p) => p.trim().length > 0);
+    let description;
+    let body;
 
-    const description = firstPara
-        ? truncateAtSentence(firstPara, 150)
-        : truncateAtSentence(topic.angle, 150);
+    const descMatch = raw.match(/<description>([\s\S]*?)<\/description>/);
+    if (descMatch) {
+        description = descMatch[1].trim();
+        body = raw.replace(/<description>[\s\S]*?<\/description>/, '').trim();
+    } else {
+        const firstPara = raw.split('\n\n').find((p) => p.trim().length > 0);
+        description = firstPara
+            ? truncateAtSentence(firstPara, 150)
+            : truncateAtSentence(topic.angle, 150);
+        body = raw;
+    }
 
     const sanitized = description
         .replace(/\n/g, ' ')


### PR DESCRIPTION
## Summary

- Updated `write-post-prompt.md` with rules for SEO description format, sentence-case headings, headings distinct from title, and code API correctness
- Updated `write-post.mjs` to parse `<description>` tag from LLM response instead of mechanically truncating the first paragraph
- Updated `revise-post-prompt.md` with same heading casing and code accuracy rules
- Removed `branch_exists` constraint on the revise step in `blog-writer.yml` so it runs on new posts too (auto-fix before PR)

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes
- [x] `npm run format` applied