### PR TITLE
feat: add auto dark mode via prefers-color-scheme

### DIFF
--- a/src/components/atoms/tagLink.astro
+++ b/src/components/atoms/tagLink.astro
@@ -10,7 +10,7 @@ const { tag } = Astro.props;
 
 <a
     href={getTagPath(tag)}
-    class="rounded-full border border-stone-300 px-3 py-1 text-sm text-stone-700 transition-colors hover:border-black hover:text-black"
+    class="rounded-full border border-stone-300 px-3 py-1 text-sm text-stone-700 transition-colors hover:border-black hover:text-black dark:border-stone-600 dark:text-stone-300 dark:hover:border-white dark:hover:text-white"
 >
     #{tag}
 </a>

--- a/src/components/elements/postItem.astro
+++ b/src/components/elements/postItem.astro
@@ -17,7 +17,7 @@ const borderClass = isLast
     <h2 class="mb-2 text-2xl font-semibold">
         <a
             href={`/posts/${post.id}`}
-            class="hover:text-black/60 dark:hover:text-white/60"
+            class="hover:text-black/60 dark:text-white dark:hover:text-white/60"
         >
             {post.data.title}
         </a>

--- a/src/components/elements/postItem.astro
+++ b/src/components/elements/postItem.astro
@@ -8,19 +8,24 @@ type Props = {
     isLast: boolean;
 };
 const { post, isLast } = Astro.props;
-const borderClass = isLast ? 'border-none' : 'border-b border-stone-200';
+const borderClass = isLast
+    ? 'border-none'
+    : 'border-b border-stone-200 dark:border-stone-700';
 ---
 
 <article class={`pb-8 ${borderClass}`}>
     <h2 class="mb-2 text-2xl font-semibold">
-        <a href={`/posts/${post.id}`} class="hover:text-black/60">
+        <a
+            href={`/posts/${post.id}`}
+            class="hover:text-black/60 dark:hover:text-white/60"
+        >
             {post.data.title}
         </a>
     </h2>
-    <p class="mb-4 text-black/40">
+    <p class="mb-4 text-black/40 dark:text-white/40">
         {formatDate(post.data.pubDate)}
     </p>
-    <p class="text-black/60">
+    <p class="text-black/60 dark:text-white/60">
         {post.data.description}
     </p>
     {

--- a/src/components/sections/hero.astro
+++ b/src/components/sections/hero.astro
@@ -10,7 +10,7 @@ import PageSection from './pageSection.astro';
     <div slot="top" class="self-end p-4">
         <a
             href="/posts/10247-lines-of-code"
-            class="text-black/60 hover:text-black/70"
+            class="text-black/60 hover:text-black/70 dark:text-white/60 dark:hover:text-white/70"
         >
             10247 lines of code
         </a>
@@ -36,7 +36,10 @@ import PageSection from './pageSection.astro';
             />
         </li>
     </ul>
-    <div slot="bottom" class="justify-self-end p-4 text-black/60">
+    <div
+        slot="bottom"
+        class="justify-self-end p-4 text-black/60 dark:text-white/60"
+    >
         <span id="current-date"></span>
     </div>
 </PageSection>

--- a/src/components/sections/pageSection.astro
+++ b/src/components/sections/pageSection.astro
@@ -17,18 +17,24 @@ const {
 
 const containerClasses =
     layout === 'grid'
-        ? 'container mx-auto grid min-h-screen sm:border-r sm:border-l sm:border-stone-200'
-        : 'container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200';
+        ? 'container mx-auto grid min-h-screen sm:border-r sm:border-l sm:border-stone-200 dark:sm:border-stone-700'
+        : 'container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200 dark:sm:border-stone-700';
 
 const bottomTextClasses =
     layout === 'grid'
-        ? 'justify-self-end p-4 text-black/60 hover:text-black/70'
-        : 'self-end p-4 text-black/60 hover:text-black/70';
+        ? 'justify-self-end p-4 text-black/60 hover:text-black/70 dark:text-white/60 dark:hover:text-white/70'
+        : 'self-end p-4 text-black/60 hover:text-black/70 dark:text-white/60 dark:hover:text-white/70';
 ---
 
-<section class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20">
+<section
+    class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20 dark:bg-gradient-to-br dark:from-slate-900 dark:to-purple-950"
+>
     <div class={containerClasses}>
-        {topText && <p class="p-4 text-black/60">{topText}</p>}
+        {
+            topText && (
+                <p class="p-4 text-black/60 dark:text-white/60">{topText}</p>
+            )
+        }
         <slot name="top" />
         <div
             class:list={[

--- a/src/layouts/blogPost.astro
+++ b/src/layouts/blogPost.astro
@@ -46,18 +46,22 @@ const blogPostingStructuredData = {
     structuredData={blogPostingStructuredData}
 >
     <section
-        class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20"
+        class="bg-gradient-to-br from-cyan-50 to-fuchsia-100 px-0 sm:px-20 dark:bg-gradient-to-br dark:from-slate-900 dark:to-purple-950"
     >
         <div
-            class="container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200"
+            class="container mx-auto flex min-h-screen flex-col sm:border-r sm:border-l sm:border-stone-200 dark:sm:border-stone-700"
         >
-            <p class="p-4 text-black/60">Another wonderful day</p>
+            <p class="p-4 text-black/60 dark:text-white/60">
+                Another wonderful day
+            </p>
             <div
                 class="line-before line-after relative flex-1 p-4 md:p-16 xl:py-32"
             >
-                <article class="prose prose-stone max-w-[720px]">
+                <article
+                    class="prose prose-stone dark:prose-invert max-w-[720px]"
+                >
                     <h1>{frontmatter.title}</h1>
-                    <div class="mb-6 text-stone-500">
+                    <div class="mb-6 text-stone-500 dark:text-stone-400">
                         <p>{publishDate}</p>
                         {updatedDate && <p>Updated {updatedDate}</p>}
                     </div>
@@ -72,7 +76,7 @@ const blogPostingStructuredData = {
                     }
                     {
                         frontmatter.aiGeneratedContent && (
-                            <div class="my-8 rounded-lg bg-amber-300 p-4">
+                            <div class="my-8 rounded-lg bg-amber-300 p-4 dark:bg-amber-900">
                                 <span class="text-xl font-bold">
                                     Disclaimer
                                 </span>
@@ -92,7 +96,7 @@ const blogPostingStructuredData = {
             </div>
             <a
                 href="/posts"
-                class="self-end p-4 text-black/60 hover:text-black/70"
+                class="self-end p-4 text-black/60 hover:text-black/70 dark:text-white/60 dark:hover:text-white/70"
             >
                 &larr; Back to Posts
             </a>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -54,6 +54,7 @@ const imageMimeType = image ? undefined : 'image/webp';
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="color-scheme" content="light dark" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link
             rel="preload"

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,7 +10,9 @@ import PageSection from '../components/sections/pageSection.astro';
         layout="grid"
         contentClass="flex w-full flex-col items-center justify-center gap-6 text-center sm:items-start sm:text-start"
     >
-        <p slot="top" class="self-end p-4 text-black/60">Are you lost?</p>
+        <p slot="top" class="self-end p-4 text-black/60 dark:text-white/60">
+            Are you lost?
+        </p>
         <h1 class="text-8xl">404</h1>
     </PageSection>
 </Layout>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -39,7 +39,9 @@ const tags = await getAllPublishedTags();
                     ))}
                 </div>
             ) : (
-                <p class="text-black/60">No blog posts found.</p>
+                <p class="text-black/60 dark:text-white/60">
+                    No blog posts found.
+                </p>
             )
         }
     </PageSection>

--- a/src/pages/posts/tags/[tag].astro
+++ b/src/pages/posts/tags/[tag].astro
@@ -30,7 +30,7 @@ const posts = await getPublishedPostsByTag(tag);
         bottomText="← Back to Posts"
     >
         <h1 class="mb-3 text-4xl font-bold">#{tag}</h1>
-        <p class="mb-8 text-stone-600">
+        <p class="mb-8 text-stone-600 dark:text-stone-400">
             {posts.length} post{posts.length === 1 ? '' : 's'}
         </p>
         {
@@ -44,7 +44,9 @@ const posts = await getPublishedPostsByTag(tag);
                     ))}
                 </div>
             ) : (
-                <p class="text-black/60">No posts found for this tag.</p>
+                <p class="text-black/60 dark:text-white/60">
+                    No posts found for this tag.
+                </p>
             )
         }
     </PageSection>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
+@custom-variant dark (@media (prefers-color-scheme: dark));
 
 @font-face {
   font-family: "Saira";
@@ -35,21 +36,21 @@ body {
 }
 
 *::selection {
-  @apply bg-emerald-300;
+  @apply bg-emerald-300 dark:bg-emerald-600;
 }
 
 .skip-link {
-  @apply fixed -top-full left-4 z-[9999] rounded-md bg-white px-4 py-2 text-sm font-semibold text-black shadow-lg ring-2 ring-emerald-300 transition-all duration-150 outline-none focus:top-4;
+  @apply fixed -top-full left-4 z-[9999] rounded-md bg-white px-4 py-2 text-sm font-semibold text-black shadow-lg ring-2 ring-emerald-300 transition-all duration-150 outline-none focus:top-4 dark:bg-gray-950 dark:text-white dark:ring-emerald-600;
 }
 
 .line-before {
-  @apply before:absolute before:top-0 before:left-1/2 before:h-px before:w-[100vw] before:-translate-x-1/2 before:bg-stone-200;
+  @apply before:absolute before:top-0 before:left-1/2 before:h-px before:w-[100vw] before:-translate-x-1/2 before:bg-stone-200 dark:before:bg-stone-700;
 }
 
 .line-after {
-  @apply after:absolute after:bottom-0 after:left-1/2 after:h-px after:w-[100vw] after:-translate-x-1/2 after:bg-stone-200;
+  @apply after:absolute after:bottom-0 after:left-1/2 after:h-px after:w-[100vw] after:-translate-x-1/2 after:bg-stone-200 dark:after:bg-stone-700;
 }
 
 .link {
-  @apply relative inline-block p-2 before:absolute before:inset-0 before:origin-bottom before:scale-y-10 before:transform before:bg-emerald-300 before:transition-transform before:duration-300 before:ease-in-out hover:before:scale-y-100;
+  @apply relative inline-block p-2 before:absolute before:inset-0 before:origin-bottom before:scale-y-10 before:transform before:bg-emerald-300 before:transition-transform before:duration-300 before:ease-in-out hover:before:scale-y-100 dark:before:bg-emerald-600;
 }


### PR DESCRIPTION
## Summary

Adds auto dark mode using `@custom-variant dark (@media (prefers-color-scheme: dark))` — a JavaScript-free, Tailwind v4-native approach. Also adds the required `<meta name="color-scheme" content="light dark" />` to prevent browser color inversion.

Includes a consistency fix for the post title link class (`dark:text-white`).

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes (type check)