### PR TITLE
feat(rss): add full content to RSS feed

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -19,6 +19,7 @@ export const GET: APIRoute = async (context) => {
             description: post.data.description,
             pubDate: post.data.pubDate,
             link: new URL(`/posts/${post.id}/`, context.site).toString(),
+            content: post.rendered?.html ?? '',
         })),
         customData: `<language>en-us</language>`,
     });


### PR DESCRIPTION
## Story

[LYO-47](https://linear.app/lyonsun7/issue/LYO-47)

## Summary

Adds `content: post.rendered?.html ?? ''` to RSS items so subscribers receive the full post body via `<content:encoded>` instead of just excerpts.

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes (type check)
- [x] `npm run format` applied (Prettier)
- [x] RSS XML verified to include `<content:encoded>` per item