### PR TITLE
chore(topic-advisor): fix pluralization and improve generation prompt

### DIFF
--- a/.github/scripts/topic-advisor-prompt.md
+++ b/.github/scripts/topic-advisor-prompt.md
@@ -6,6 +6,7 @@ You are a topic advisor for a personal technical blog. Your role is to strategic
 - Topics must be practical, technically substantive, and worth a full blog post (300-500 words).
 - Avoid generic or overdone topics. Prioritize novel angles, emerging patterns, and concrete engineering challenges.
 - Use sentence case for titles.
+- Acronyms in titles must be uppercase (e.g., `LLM`, `API`, `AI`, `CI/CD`).
 
 # Output format
 
@@ -15,7 +16,7 @@ Return ONLY a valid JSON array of objects, each with these exact fields:
 - `title`: Sentence case title (e.g., "Debugging distributed systems in production").
 - `angle`: 1-2 sentence description of the specific angle or thesis for the post. Must be different from existing topics.
 - `rationale`: 1-2 sentences explaining why this topic is worth writing now — what makes it timely, what gap it fills, or why readers will care.
-- `tags`: Array of 2-4 lowercase tag strings. Reuse existing tags when appropriate; invent new ones only when necessary.
+- `tags`: Array of 2-4 lowercase tag strings. Reuse existing tags when possible. Prefer existing tags over introducing new ones (e.g., use `llm` not `llms`, `frontend` not `frontend-development`). Only introduce new tags when no existing tag fits the concept.
 
 Example:
 

--- a/.github/scripts/topic-advisor.mjs
+++ b/.github/scripts/topic-advisor.mjs
@@ -9,6 +9,10 @@ const PROMPT_PATH = join(__dirname, 'topic-advisor-prompt.md');
 const TOPICS_PATH = join(__dirname, 'topics.json');
 const POSTS_DIR = join(__dirname, '..', '..', 'src', 'content', 'posts');
 
+function pluralize(count) {
+    return count === 1 ? 'topic' : 'topics';
+}
+
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 const GROQ_MODEL = 'llama-3.3-70b-versatile';
 const TARGET_UNUSED = 10;
@@ -163,7 +167,7 @@ async function main() {
     }
 
     console.log(
-        `Queue has ${unusedTopics.length} unused topics. Generating ${countNeeded} new topic(s).`,
+        `Queue has ${unusedTopics.length} unused topics. Generating ${countNeeded} new ${pluralize(countNeeded)}.`,
     );
 
     const existingContext = buildExistingContext(topics, postSlugs);
@@ -204,7 +208,7 @@ async function main() {
 
     if (dryRun) {
         console.log(
-            `[dry-run] Would add ${added.length} topic(s). Final unused: ${finalCount}.`,
+            `[dry-run] Would add ${added.length} ${pluralize(added.length)}. Final unused: ${finalCount}.`,
         );
         for (const t of added) {
             console.log(`  + ${t.title} [${t.tags.join(', ')}]`);
@@ -214,7 +218,7 @@ async function main() {
 
     writeTopics(topics);
     console.log(
-        `Added ${added.length} topic(s). Queue now has ${finalCount} unused topics.`,
+        `Added ${added.length} ${pluralize(added.length)}. Queue now has ${finalCount} unused topics.`,
     );
     for (const t of added) {
         console.log(`  + ${t.title} [${t.tags.join(', ')}]`);
@@ -227,7 +231,7 @@ async function main() {
         );
 
         const prBodyLines = [
-            `This PR adds ${added.length} new topic(s) to the queue, generated via LLM.`,
+            `This PR adds ${added.length} new ${pluralize(added.length)} to the queue, generated via LLM.`,
             '',
             '## New topics',
             ...added.map((t) => `- **${t.title}** — ${t.rationale}`),


### PR DESCRIPTION
## Summary
- Replace "topic(s)" awkward pluralization with proper `pluralize()` helper
- Add acronym casing rule to prompt (LLM, API, AI, CI/CD must be uppercase)
- Strengthen tag convention instruction with explicit examples (use `llm` not `llms`, `frontend` not `frontend-development`)

## Test Plan
- [x] `node --check .github/scripts/topic-advisor.mjs` passes
- [x] `npm run check` passes