### PR TITLE
fix: stop managing updatedAt field in revision script

### DIFF
--- a/.github/scripts/revise-post.mjs
+++ b/.github/scripts/revise-post.mjs
@@ -97,12 +97,7 @@ async function main() {
         process.exit(0);
     }
 
-    const today = new Date().toISOString().slice(0, 10);
-    const updatedFrontmatter = frontmatter.includes('updatedAt:')
-        ? frontmatter.replace(/updatedAt:.*/, `updatedAt: ${today}`)
-        : `${frontmatter}\nupdatedAt: ${today}`;
-
-    const newContent = `---\n${updatedFrontmatter}\n---\n\n${revisedBody}\n`;
+    const newContent = `---\n${frontmatter}\n---\n\n${revisedBody}\n`;
     writeFileSync(filePath, newContent);
 
     try {


### PR DESCRIPTION
## Summary

Remove the `updatedAt` frontmatter management from the revision script. The revision step (revise-post.mjs) was unconditionally adding/updating `updatedAt` to today's date on every revision run, causing new posts to get `updatedAt` set to the same date as `pubDate` — which is misleading since the post hasn't actually been updated.

This field should be set manually when a human genuinely updates a post, not managed by the automated CI script.

Fixes the consistency issue raised in PR #120 review.

## Verification

- [x] `npm run build` succeeds
- [x] `npm run check` passes (type check)
- [x] `npm run format` applied (Prettier)