### PR TITLE
fix(renovate): disable npm packageManager auto-updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
+      "matchDepNames": ["npm"],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "non-major updates"
     }


### PR DESCRIPTION
## Summary

Renovate has been repeatedly failing its `renovate/artifacts` check on PRs that update the `npm` package (which controls the `packageManager` field in `package.json`). The artifact post-update step (regenerating `package-lock.json`) fails, causing a stuck failing check on every `non-major-updates` PR.

Adding a `packageRules` entry to disable auto-updates for the `npm` dep. We'll manage the `packageManager` field manually.

Closes the failing PRs #110 and #123.

## Verification

- [ ] `npm run build` succeeds
- [ ] `npm run check` passes
- [ ] `npm run format` applied